### PR TITLE
Add methods for equality and order comparisons

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,10 @@ toc::[]
 * Add methods to subtract from/to `SystemTime`
 * Add methods to subtract from/to `time::OffsetDateTime`
 * Add methods to subtract from/to `chrono::DateTime<chrono::Utc>`
+* Add methods for equality comparisons from/to `SystemTime`,
+  `time::OffsetDateTime` and `chrono::DateTime<chrono::Utc>`
+* Add methods for order comparisons from/to `SystemTime`,
+  `time::OffsetDateTime` and `chrono::DateTime<chrono::Utc>`
 
 === Changed
 

--- a/src/filetime.rs
+++ b/src/filetime.rs
@@ -9,6 +9,7 @@
 //! [file-time-docs-url]: https://docs.microsoft.com/en-us/windows/win32/sysinfo/file-times
 
 use core::{
+    cmp::Ordering,
     fmt, mem,
     ops::{Add, AddAssign, Sub, SubAssign},
 };
@@ -395,6 +396,119 @@ impl fmt::Display for FileTime {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         u64::from(*self).fmt(f)
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+impl PartialEq<FileTime> for std::time::SystemTime {
+    #[inline]
+    fn eq(&self, other: &FileTime) -> bool {
+        self == &Self::from(*other)
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+impl PartialEq<std::time::SystemTime> for FileTime {
+    #[inline]
+    fn eq(&self, other: &std::time::SystemTime) -> bool {
+        use std::time::SystemTime;
+
+        &SystemTime::from(*self) == other
+    }
+}
+
+impl PartialEq<FileTime> for OffsetDateTime {
+    #[inline]
+    fn eq(&self, other: &FileTime) -> bool {
+        self == &Self::try_from(*other).expect("`other` is out of range for `OffsetDateTime`")
+    }
+}
+
+impl PartialEq<OffsetDateTime> for FileTime {
+    #[inline]
+    fn eq(&self, other: &OffsetDateTime) -> bool {
+        &OffsetDateTime::try_from(*self).expect("`self` is out of range for `OffsetDateTime`")
+            == other
+    }
+}
+
+#[cfg(feature = "chrono")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
+impl PartialEq<FileTime> for chrono::DateTime<chrono::Utc> {
+    #[inline]
+    fn eq(&self, other: &FileTime) -> bool {
+        self == &Self::from(*other)
+    }
+}
+
+#[cfg(feature = "chrono")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
+impl PartialEq<chrono::DateTime<chrono::Utc>> for FileTime {
+    #[inline]
+    fn eq(&self, other: &chrono::DateTime<chrono::Utc>) -> bool {
+        use chrono::{DateTime, Utc};
+
+        &DateTime::<Utc>::from(*self) == other
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+impl PartialOrd<FileTime> for std::time::SystemTime {
+    #[inline]
+    fn partial_cmp(&self, other: &FileTime) -> Option<Ordering> {
+        self.partial_cmp(&Self::from(*other))
+    }
+}
+
+#[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+impl PartialOrd<std::time::SystemTime> for FileTime {
+    #[inline]
+    fn partial_cmp(&self, other: &std::time::SystemTime) -> Option<Ordering> {
+        use std::time::SystemTime;
+
+        SystemTime::from(*self).partial_cmp(other)
+    }
+}
+
+impl PartialOrd<FileTime> for OffsetDateTime {
+    #[inline]
+    fn partial_cmp(&self, other: &FileTime) -> Option<Ordering> {
+        self.partial_cmp(
+            &Self::try_from(*other).expect("`other` is out of range for `OffsetDateTime`"),
+        )
+    }
+}
+
+impl PartialOrd<OffsetDateTime> for FileTime {
+    #[inline]
+    fn partial_cmp(&self, other: &OffsetDateTime) -> Option<Ordering> {
+        OffsetDateTime::try_from(*self)
+            .expect("`self` is out of range for `OffsetDateTime`")
+            .partial_cmp(other)
+    }
+}
+
+#[cfg(feature = "chrono")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
+impl PartialOrd<FileTime> for chrono::DateTime<chrono::Utc> {
+    #[inline]
+    fn partial_cmp(&self, other: &FileTime) -> Option<Ordering> {
+        self.partial_cmp(&Self::from(*other))
+    }
+}
+
+#[cfg(feature = "chrono")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
+impl PartialOrd<chrono::DateTime<chrono::Utc>> for FileTime {
+    #[inline]
+    fn partial_cmp(&self, other: &chrono::DateTime<chrono::Utc>) -> Option<Ordering> {
+        use chrono::{DateTime, Utc};
+
+        DateTime::<Utc>::from(*self).partial_cmp(other)
     }
 }
 
@@ -952,6 +1066,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn equality() {
+        assert_eq!(FileTime::NT_EPOCH, FileTime::NT_EPOCH);
+        assert_ne!(FileTime::NT_EPOCH, FileTime::UNIX_EPOCH);
+        assert_ne!(FileTime::NT_EPOCH, FileTime::MAX);
+        assert_ne!(FileTime::UNIX_EPOCH, FileTime::NT_EPOCH);
+        assert_eq!(FileTime::UNIX_EPOCH, FileTime::UNIX_EPOCH);
+        assert_ne!(FileTime::UNIX_EPOCH, FileTime::MAX);
+        assert_ne!(FileTime::MAX, FileTime::NT_EPOCH);
+        assert_ne!(FileTime::MAX, FileTime::UNIX_EPOCH);
+        assert_eq!(FileTime::MAX, FileTime::MAX);
+    }
+
+    #[test]
+    fn order() {
+        assert_eq!(FileTime::UNIX_EPOCH.cmp(&FileTime::MAX), Ordering::Less);
+        assert_eq!(
+            FileTime::UNIX_EPOCH.cmp(&FileTime::UNIX_EPOCH),
+            Ordering::Equal
+        );
+        assert_eq!(
+            FileTime::UNIX_EPOCH.cmp(&FileTime::NT_EPOCH),
+            Ordering::Greater
+        );
+    }
+
     #[cfg(feature = "std")]
     #[test]
     fn hash() {
@@ -972,23 +1112,6 @@ mod tests {
                 hasher.finish()
             }
         );
-    }
-
-    #[test]
-    fn order() {
-        use core::cmp::Ordering;
-
-        assert_eq!(FileTime::NT_EPOCH.cmp(&FileTime::MAX), Ordering::Less);
-        assert_eq!(FileTime::NT_EPOCH.cmp(&FileTime::NT_EPOCH), Ordering::Equal);
-        assert_eq!(FileTime::MAX.cmp(&FileTime::NT_EPOCH), Ordering::Greater);
-    }
-
-    #[test]
-    fn equality() {
-        assert_eq!(FileTime::NT_EPOCH, FileTime::NT_EPOCH);
-        assert_ne!(FileTime::NT_EPOCH, FileTime::MAX);
-        assert_ne!(FileTime::MAX, FileTime::NT_EPOCH);
-        assert_eq!(FileTime::MAX, FileTime::MAX);
     }
 
     #[test]
@@ -1235,6 +1358,240 @@ mod tests {
         assert_eq!(format!("{}", FileTime::NT_EPOCH), "0");
         assert_eq!(format!("{}", FileTime::UNIX_EPOCH), "116444736000000000");
         assert_eq!(format!("{}", FileTime::MAX), "18446744073709551615");
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn equality_system_time_and_file_time() {
+        use std::time::{Duration, SystemTime};
+
+        assert_eq!(
+            (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700)),
+            FileTime::new(9_223_372_036_854_775_807)
+        );
+        assert_ne!(
+            (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700)),
+            FileTime::new(9_223_372_036_854_775_806)
+        );
+        assert_eq!(SystemTime::UNIX_EPOCH, FileTime::UNIX_EPOCH);
+        assert_ne!(SystemTime::UNIX_EPOCH, FileTime::NT_EPOCH);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn equality_file_time_and_system_time() {
+        use std::time::{Duration, SystemTime};
+
+        assert_eq!(
+            FileTime::new(9_223_372_036_854_775_807),
+            (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700))
+        );
+        assert_ne!(
+            FileTime::new(9_223_372_036_854_775_806),
+            (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700))
+        );
+        assert_eq!(FileTime::UNIX_EPOCH, SystemTime::UNIX_EPOCH);
+        assert_ne!(FileTime::NT_EPOCH, SystemTime::UNIX_EPOCH);
+    }
+
+    #[test]
+    fn equality_offset_date_time_and_file_time() {
+        assert_eq!(
+            datetime!(9999-12-31 23:59:59.999_999_900 UTC),
+            FileTime::new(2_650_467_743_999_999_999)
+        );
+        assert_ne!(
+            datetime!(9999-12-31 23:59:59.999_999_900 UTC),
+            FileTime::NT_EPOCH
+        );
+        assert_ne!(
+            OFFSET_DATE_TIME_NT_EPOCH,
+            FileTime::new(2_650_467_743_999_999_999)
+        );
+        assert_eq!(OFFSET_DATE_TIME_NT_EPOCH, FileTime::NT_EPOCH);
+    }
+
+    #[test]
+    fn equality_file_time_and_offset_date_time() {
+        assert_eq!(
+            FileTime::new(2_650_467_743_999_999_999),
+            datetime!(9999-12-31 23:59:59.999_999_900 UTC)
+        );
+        assert_ne!(
+            FileTime::NT_EPOCH,
+            datetime!(9999-12-31 23:59:59.999_999_900 UTC)
+        );
+        assert_ne!(
+            FileTime::new(2_650_467_743_999_999_999),
+            OFFSET_DATE_TIME_NT_EPOCH
+        );
+        assert_eq!(FileTime::NT_EPOCH, OFFSET_DATE_TIME_NT_EPOCH);
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn equality_chrono_date_time_and_file_time() {
+        use chrono::{DateTime, Utc};
+
+        assert_eq!(
+            "+60056-05-28 05:36:10.955161500 UTC"
+                .parse::<DateTime<Utc>>()
+                .unwrap(),
+            FileTime::MAX
+        );
+        assert_ne!(
+            "+60056-05-28 05:36:10.955161500 UTC"
+                .parse::<DateTime<Utc>>()
+                .unwrap(),
+            FileTime::NT_EPOCH
+        );
+        assert_ne!(*CHRONO_DATE_TIME_NT_EPOCH, FileTime::MAX);
+        assert_eq!(*CHRONO_DATE_TIME_NT_EPOCH, FileTime::NT_EPOCH);
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn equality_file_time_and_chrono_date_time() {
+        use chrono::{DateTime, Utc};
+
+        assert_eq!(
+            FileTime::MAX,
+            "+60056-05-28 05:36:10.955161500 UTC"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
+        assert_ne!(
+            FileTime::NT_EPOCH,
+            "+60056-05-28 05:36:10.955161500 UTC"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+        );
+        assert_ne!(FileTime::MAX, *CHRONO_DATE_TIME_NT_EPOCH);
+        assert_eq!(FileTime::NT_EPOCH, *CHRONO_DATE_TIME_NT_EPOCH);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn order_system_time_and_file_time() {
+        use std::time::SystemTime;
+
+        assert_eq!(
+            SystemTime::UNIX_EPOCH.partial_cmp(&FileTime::new(9_223_372_036_854_775_807)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            SystemTime::UNIX_EPOCH.partial_cmp(&FileTime::UNIX_EPOCH),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            SystemTime::UNIX_EPOCH.partial_cmp(&FileTime::NT_EPOCH),
+            Some(Ordering::Greater)
+        );
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn order_file_time_and_system_time() {
+        use std::time::{Duration, SystemTime};
+
+        assert_eq!(
+            FileTime::UNIX_EPOCH.partial_cmp(
+                &(SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700))
+            ),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            FileTime::UNIX_EPOCH.partial_cmp(&SystemTime::UNIX_EPOCH),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            FileTime::UNIX_EPOCH.partial_cmp(&*SYSTEM_TIME_NT_EPOCH),
+            Some(Ordering::Greater)
+        );
+    }
+
+    #[test]
+    fn order_offset_date_time_and_file_time() {
+        assert_eq!(
+            OffsetDateTime::UNIX_EPOCH.partial_cmp(&FileTime::new(2_650_467_743_999_999_999)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            OffsetDateTime::UNIX_EPOCH.partial_cmp(&FileTime::UNIX_EPOCH),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            OffsetDateTime::UNIX_EPOCH.partial_cmp(&FileTime::NT_EPOCH),
+            Some(Ordering::Greater)
+        );
+    }
+
+    #[test]
+    fn order_file_time_and_offset_date_time() {
+        assert_eq!(
+            FileTime::UNIX_EPOCH.partial_cmp(&datetime!(9999-12-31 23:59:59.999_999_900 UTC)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            FileTime::UNIX_EPOCH.partial_cmp(&OffsetDateTime::UNIX_EPOCH),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            FileTime::UNIX_EPOCH.partial_cmp(&OFFSET_DATE_TIME_NT_EPOCH),
+            Some(Ordering::Greater)
+        );
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn order_chrono_date_time_and_file_time() {
+        use chrono::{DateTime, Utc};
+
+        assert_eq!(
+            "1970-01-01 00:00:00 UTC"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+                .partial_cmp(&FileTime::MAX),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            "1970-01-01 00:00:00 UTC"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+                .partial_cmp(&FileTime::UNIX_EPOCH),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            "1970-01-01 00:00:00 UTC"
+                .parse::<DateTime<Utc>>()
+                .unwrap()
+                .partial_cmp(&FileTime::NT_EPOCH),
+            Some(Ordering::Greater)
+        );
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn order_file_time_and_chrono_date_time() {
+        use chrono::{DateTime, Utc};
+
+        assert_eq!(
+            FileTime::UNIX_EPOCH.partial_cmp(
+                &"+60056-05-28 05:36:10.955161500 UTC"
+                    .parse::<DateTime<Utc>>()
+                    .unwrap()
+            ),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            FileTime::UNIX_EPOCH
+                .partial_cmp(&"1970-01-01 00:00:00 UTC".parse::<DateTime<Utc>>().unwrap()),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            FileTime::UNIX_EPOCH.partial_cmp(&*CHRONO_DATE_TIME_NT_EPOCH),
+            Some(Ordering::Greater)
+        );
     }
 
     #[test]


### PR DESCRIPTION
1. Add methods for equality comparisons from/to `SystemTime`, `time::OffsetDateTime` and `chrono::DateTime<chrono::Utc>`
2. Add methods for order comparisons from/to `SystemTime`, `time::OffsetDateTime` and `chrono::DateTime<chrono::Utc>`