### PR TITLE
Add Serde support

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -39,18 +39,16 @@ jobs:
       uses: Swatinem/rust-cache@v2.2.1
       with:
         key: ${{ matrix.target }}
-    - name: Build a package
-      run: cargo build --target ${{ matrix.target }}
-    - name: Build a package (all features)
-      run: cargo build --target ${{ matrix.target }} --all-features
-    - name: Build a package (no default features)
-      run: cargo build --target ${{ matrix.target }} --no-default-features
     - name: Run tests
       run: cargo test --target ${{ matrix.target }}
     - name: Run tests (all features)
       run: cargo test --target ${{ matrix.target }} --all-features
     - name: Run tests (no default features)
       run: cargo test --target ${{ matrix.target }} --no-default-features
+    - run: cargo test --target ${{ matrix.target }} -F serde-human-readable
+    - run: cargo test --target ${{ matrix.target }} -F large-dates,serde-human-readable
+    - run: cargo test --target ${{ matrix.target }} --no-default-features -F serde-human-readable
+    - run: cargo test --target ${{ matrix.target }} --no-default-features -F large-dates,serde-human-readable
 
   rustfmt:
     name: Rustfmt

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,12 @@ project adheres to https://semver.org/[Semantic Versioning].
 
 toc::[]
 
+== {compare-url}/v0.2.0\...HEAD[Unreleased]
+
+=== Added
+
+* Add Serde support
+
 == {compare-url}/v0.1.0\...v0.2.0[0.2.0] - 2023-04-14
 
 === Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,14 @@ exclude = [
 [dependencies]
 chrono = { version = "0.4.24", default-features = false, optional = true }
 once_cell = { version = "1.17.1", default-features = false, features = ["critical-section"], optional = true }
+serde = { version = "1.0.160", default-features = false, features = ["derive"], optional = true }
 time = { version = "0.3.20", default-features = false, features = ["macros"] }
 
 [dev-dependencies]
 anyhow = "1.0.70"
 clap = { version = "3.2.23", features = ["derive"] }
+serde_json = "1.0.96"
+serde_test = "1.0.160"
 
 [features]
 default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ default = ["std"]
 std = ["dep:once_cell", "time/std", "chrono?/std"]
 large-dates = ["time/large-dates"]
 chrono = ["dep:chrono", "dep:once_cell"]
+serde-human-readable = ["serde", "time/serde-human-readable"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Enables the `large-dates` feature of the [`time`][time-crate-url] crate.
 
 Enables the [`chrono`][chrono-crate-url] crate.
 
+#### `serde`
+
+Enables the [`serde`][serde-official-url] crate.
+
 ### `no_std` support
 
 This supports `no_std` mode.
@@ -98,3 +102,4 @@ See [COPYRIGHT](COPYRIGHT), [LICENSE-APACHE](LICENSE-APACHE) and
 [rust-official-url]: https://www.rust-lang.org/
 [time-crate-url]: https://crates.io/crates/time
 [chrono-crate-url]: https://crates.io/crates/chrono
+[serde-official-url]: https://serde.rs/

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Enables the [`chrono`][chrono-crate-url] crate.
 
 Enables the [`serde`][serde-official-url] crate.
 
+#### `serde-human-readable`
+
+Enables the `serde-human-readable` feature of the [`serde`][serde-official-url]
+crate.
+
 ### `no_std` support
 
 This supports `no_std` mode.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ Enables the [`serde`][serde-official-url] crate.
 
 #### `serde-human-readable`
 
-Enables the `serde-human-readable` feature of the [`serde`][serde-official-url]
-crate.
+Allows Serde representations to use a human-readable format.
+This implicitly enables the `serde` feature.
+If this feature is not enabled, the underlying 64-bit unsigned integer format
+will be used.
 
 ### `no_std` support
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,6 @@ impl fmt::Display for OffsetDateTimeRangeError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for OffsetDateTimeRangeError {}
 
 /// The error type indicating that a [`FileTime`](crate::FileTime) was out of
@@ -60,7 +59,6 @@ impl fmt::Display for FileTimeRangeError {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for FileTimeRangeError {}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/filetime.rs
+++ b/src/filetime.rs
@@ -2651,6 +2651,38 @@ mod tests {
 
     #[cfg(feature = "serde")]
     #[test]
+    fn serde_optional() {
+        use serde_test::{assert_tokens, Token};
+
+        assert_tokens(
+            &Some(FileTime::NT_EPOCH),
+            &[
+                Token::Some,
+                Token::NewtypeStruct { name: "FileTime" },
+                Token::U64(u64::MIN),
+            ],
+        );
+        assert_tokens(
+            &Some(FileTime::UNIX_EPOCH),
+            &[
+                Token::Some,
+                Token::NewtypeStruct { name: "FileTime" },
+                Token::U64(116_444_736_000_000_000),
+            ],
+        );
+        assert_tokens(
+            &Some(FileTime::MAX),
+            &[
+                Token::Some,
+                Token::NewtypeStruct { name: "FileTime" },
+                Token::U64(u64::MAX),
+            ],
+        );
+        assert_tokens(&None::<FileTime>, &[Token::None]);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
     fn serialize_json() {
         assert_eq!(serde_json::to_string(&FileTime::NT_EPOCH).unwrap(), "0");
         assert_eq!(
@@ -2661,6 +2693,24 @@ mod tests {
             serde_json::to_string(&FileTime::MAX).unwrap(),
             "18446744073709551615"
         );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize_optional_json() {
+        assert_eq!(
+            serde_json::to_string(&Some(FileTime::NT_EPOCH)).unwrap(),
+            "0"
+        );
+        assert_eq!(
+            serde_json::to_string(&Some(FileTime::UNIX_EPOCH)).unwrap(),
+            "116444736000000000"
+        );
+        assert_eq!(
+            serde_json::to_string(&Some(FileTime::MAX)).unwrap(),
+            "18446744073709551615"
+        );
+        assert_eq!(serde_json::to_string(&None::<FileTime>).unwrap(), "null");
     }
 
     #[cfg(feature = "serde")]
@@ -2677,6 +2727,27 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<FileTime>("18446744073709551615").unwrap(),
             FileTime::MAX
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize_optional_json() {
+        assert_eq!(
+            serde_json::from_str::<Option<FileTime>>("0").unwrap(),
+            Some(FileTime::NT_EPOCH)
+        );
+        assert_eq!(
+            serde_json::from_str::<Option<FileTime>>("116444736000000000").unwrap(),
+            Some(FileTime::UNIX_EPOCH)
+        );
+        assert_eq!(
+            serde_json::from_str::<Option<FileTime>>("18446744073709551615").unwrap(),
+            Some(FileTime::MAX)
+        );
+        assert_eq!(
+            serde_json::from_str::<Option<FileTime>>("null").unwrap(),
+            None
         );
     }
 }

--- a/src/filetime.rs
+++ b/src/filetime.rs
@@ -120,7 +120,6 @@ impl FileTime {
     /// let now = FileTime::now();
     /// ```
     #[cfg(feature = "std")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
     #[must_use]
     pub fn now() -> Self {
         use std::time::SystemTime;
@@ -404,7 +403,6 @@ impl fmt::Display for FileTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl PartialEq<FileTime> for std::time::SystemTime {
     #[inline]
     fn eq(&self, other: &FileTime) -> bool {
@@ -413,7 +411,6 @@ impl PartialEq<FileTime> for std::time::SystemTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl PartialEq<std::time::SystemTime> for FileTime {
     #[inline]
     fn eq(&self, other: &std::time::SystemTime) -> bool {
@@ -439,7 +436,6 @@ impl PartialEq<OffsetDateTime> for FileTime {
 }
 
 #[cfg(feature = "chrono")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
 impl PartialEq<FileTime> for chrono::DateTime<chrono::Utc> {
     #[inline]
     fn eq(&self, other: &FileTime) -> bool {
@@ -448,7 +444,6 @@ impl PartialEq<FileTime> for chrono::DateTime<chrono::Utc> {
 }
 
 #[cfg(feature = "chrono")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
 impl PartialEq<chrono::DateTime<chrono::Utc>> for FileTime {
     #[inline]
     fn eq(&self, other: &chrono::DateTime<chrono::Utc>) -> bool {
@@ -459,7 +454,6 @@ impl PartialEq<chrono::DateTime<chrono::Utc>> for FileTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl PartialOrd<FileTime> for std::time::SystemTime {
     #[inline]
     fn partial_cmp(&self, other: &FileTime) -> Option<Ordering> {
@@ -468,7 +462,6 @@ impl PartialOrd<FileTime> for std::time::SystemTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl PartialOrd<std::time::SystemTime> for FileTime {
     #[inline]
     fn partial_cmp(&self, other: &std::time::SystemTime) -> Option<Ordering> {
@@ -497,7 +490,6 @@ impl PartialOrd<OffsetDateTime> for FileTime {
 }
 
 #[cfg(feature = "chrono")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
 impl PartialOrd<FileTime> for chrono::DateTime<chrono::Utc> {
     #[inline]
     fn partial_cmp(&self, other: &FileTime) -> Option<Ordering> {
@@ -506,7 +498,6 @@ impl PartialOrd<FileTime> for chrono::DateTime<chrono::Utc> {
 }
 
 #[cfg(feature = "chrono")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
 impl PartialOrd<chrono::DateTime<chrono::Utc>> for FileTime {
     #[inline]
     fn partial_cmp(&self, other: &chrono::DateTime<chrono::Utc>) -> Option<Ordering> {
@@ -590,7 +581,6 @@ impl Sub<time::Duration> for FileTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl Sub<FileTime> for std::time::SystemTime {
     type Output = std::time::Duration;
 
@@ -602,7 +592,6 @@ impl Sub<FileTime> for std::time::SystemTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl Sub<std::time::SystemTime> for FileTime {
     type Output = std::time::Duration;
 
@@ -635,7 +624,6 @@ impl Sub<OffsetDateTime> for FileTime {
 }
 
 #[cfg(feature = "chrono")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
 impl Sub<FileTime> for chrono::DateTime<chrono::Utc> {
     type Output = chrono::Duration;
 
@@ -646,7 +634,6 @@ impl Sub<FileTime> for chrono::DateTime<chrono::Utc> {
 }
 
 #[cfg(feature = "chrono")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
 impl Sub<chrono::DateTime<chrono::Utc>> for FileTime {
     type Output = chrono::Duration;
 
@@ -694,7 +681,6 @@ impl From<FileTime> for u64 {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl From<FileTime> for std::time::SystemTime {
     /// Converts a `FileTime` to a [`SystemTime`](std::time::SystemTime).
     ///
@@ -812,7 +798,6 @@ impl TryFrom<FileTime> for OffsetDateTime {
 }
 
 #[cfg(feature = "chrono")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
 impl From<FileTime> for chrono::DateTime<chrono::Utc> {
     /// Converts a `FileTime` to a [`DateTime<Utc>`](chrono::DateTime).
     ///
@@ -870,7 +855,6 @@ impl From<u64> for FileTime {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl TryFrom<std::time::SystemTime> for FileTime {
     type Error = FileTimeRangeError;
 
@@ -993,7 +977,6 @@ impl TryFrom<OffsetDateTime> for FileTime {
 }
 
 #[cfg(feature = "chrono")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "chrono")))]
 impl TryFrom<chrono::DateTime<chrono::Utc>> for FileTime {
     type Error = FileTimeRangeError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,9 @@ extern crate std;
 
 pub mod error;
 mod filetime;
+#[cfg(feature = "serde-human-readable")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde-human-readable")))]
+pub mod serde;
 
 #[cfg(feature = "chrono")]
 pub use chrono;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 
 #![doc(html_root_url = "https://docs.rs/nt-time/0.2.0/")]
 #![no_std]
-#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![cfg_attr(doc_cfg, feature(doc_auto_cfg, doc_cfg))]
 // Lint levels of rustc.
 #![forbid(unsafe_code)]
 #![deny(missing_debug_implementations, missing_docs)]
@@ -55,7 +55,6 @@ extern crate std;
 pub mod error;
 mod filetime;
 #[cfg(feature = "serde-human-readable")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "serde-human-readable")))]
 pub mod serde;
 
 #[cfg(feature = "chrono")]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,13 @@
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (C) 2023 Shun Sakai
+//
+
+//! Differential formats for [Serde][serde-official-url].
+//!
+//! [serde-official-url]: https://serde.rs/
+
+pub mod iso_8601;
+pub mod rfc_2822;
+pub mod rfc_3339;

--- a/src/serde/iso_8601.rs
+++ b/src/serde/iso_8601.rs
@@ -10,6 +10,9 @@
 //! Use this module in combination with Serde's
 //! [`#[with]`][serde-with-attribute] attribute.
 //!
+//! If the `large-dates` feature is not enabled, the maximum date and time is
+//! "9999-12-31 23:59:59.999999999 UTC".
+//!
 //! # Examples
 //!
 //! ```

--- a/src/serde/iso_8601.rs
+++ b/src/serde/iso_8601.rs
@@ -1,0 +1,176 @@
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (C) 2023 Shun Sakai
+//
+
+//! Use the well-known [ISO 8601 format][iso-8601-description-url] when
+//! serializing and deserializing a [`FileTime`].
+//!
+//! Use this module in combination with Serde's
+//! [`#[with]`][serde-with-attribute] attribute.
+//!
+//! # Examples
+//!
+//! ```
+//! use nt_time::{serde::iso_8601, FileTime};
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Debug, Deserialize, PartialEq, Serialize)]
+//! struct DateTime(#[serde(with = "iso_8601")] FileTime);
+//!
+//! let json = serde_json::to_string(&DateTime(FileTime::UNIX_EPOCH)).unwrap();
+//! assert_eq!(json, r#""+001970-01-01T00:00:00.000000000Z""#);
+//!
+//! assert_eq!(
+//!     serde_json::from_str::<DateTime>(&json).unwrap(),
+//!     DateTime(FileTime::UNIX_EPOCH)
+//! );
+//! ```
+//!
+//! [iso-8601-description-url]: https://www.iso.org/iso-8601-date-and-time-format.html
+//! [serde-with-attribute]: https://serde.rs/field-attrs.html#with
+
+pub mod option;
+
+use serde::{de::Error as _, ser::Error as _, Deserializer, Serializer};
+use time::serde::iso8601;
+
+use crate::FileTime;
+
+#[allow(clippy::missing_errors_doc)]
+/// Serializes a [`FileTime`] into the given Serde serializer.
+///
+/// This serializes using the well-known ISO 8601 format.
+pub fn serialize<S: Serializer>(time: &FileTime, serializer: S) -> Result<S::Ok, S::Error> {
+    (*time)
+        .try_into()
+        .map_err(S::Error::custom)
+        .and_then(|dt| iso8601::serialize(&dt, serializer))
+}
+
+#[allow(clippy::missing_errors_doc)]
+/// Deserializes a [`FileTime`] from the given Serde deserializer.
+///
+/// This deserializes from its ISO 8601 representation.
+pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<FileTime, D::Error> {
+    iso8601::deserialize(deserializer).and_then(|dt| dt.try_into().map_err(D::Error::custom))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    struct Test(#[serde(with = "crate::serde::iso_8601")] FileTime);
+
+    #[test]
+    fn serde() {
+        assert_tokens(
+            &Test(FileTime::NT_EPOCH),
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::BorrowedStr("+001601-01-01T00:00:00.000000000Z"),
+            ],
+        );
+        assert_tokens(
+            &Test(FileTime::UNIX_EPOCH),
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::BorrowedStr("+001970-01-01T00:00:00.000000000Z"),
+            ],
+        );
+    }
+
+    #[cfg(feature = "large-dates")]
+    #[test]
+    fn serde_with_large_dates() {
+        assert_tokens(
+            &Test(FileTime::MAX),
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::BorrowedStr("+060056-05-28T05:36:10.955161500Z"),
+            ],
+        );
+    }
+
+    #[test]
+    fn deserialize_error() {
+        assert_de_tokens_error::<Test>(
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::BorrowedStr("+001600-12-31T23:59:59.999999999Z"),
+            ],
+            "date and time is before `1601-01-01 00:00:00 UTC`",
+        );
+    }
+
+    #[cfg(not(feature = "large-dates"))]
+    #[test]
+    fn deserialize_error_without_large_dates() {
+        assert_de_tokens_error::<Test>(
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::BorrowedStr("+010000-01-01T00:00:00.000000000Z"),
+            ],
+            "year must be in the range -9999..=9999",
+        );
+    }
+
+    #[cfg(feature = "large-dates")]
+    #[test]
+    fn deserialize_error_with_large_dates() {
+        assert_de_tokens_error::<Test>(
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::BorrowedStr("+060056-05-28T05:36:10.955161600Z"),
+            ],
+            "date and time is after `+60056-05-28 05:36:10.955161500 UTC`",
+        );
+    }
+
+    #[test]
+    fn serialize_json() {
+        assert_eq!(
+            serde_json::to_string(&Test(FileTime::NT_EPOCH)).unwrap(),
+            r#""+001601-01-01T00:00:00.000000000Z""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Test(FileTime::UNIX_EPOCH)).unwrap(),
+            r#""+001970-01-01T00:00:00.000000000Z""#
+        );
+    }
+
+    #[cfg(feature = "large-dates")]
+    #[test]
+    fn serialize_json_with_large_dates() {
+        assert_eq!(
+            serde_json::to_string(&Test(FileTime::MAX)).unwrap(),
+            r#""+060056-05-28T05:36:10.955161500Z""#
+        );
+    }
+
+    #[test]
+    fn deserialize_json() {
+        assert_eq!(
+            serde_json::from_str::<Test>(r#""1601-01-01T00:00:00Z""#).unwrap(),
+            Test(FileTime::NT_EPOCH)
+        );
+        assert_eq!(
+            serde_json::from_str::<Test>(r#""1970-01-01T00:00:00Z""#).unwrap(),
+            Test(FileTime::UNIX_EPOCH)
+        );
+    }
+
+    #[cfg(feature = "large-dates")]
+    #[test]
+    fn deserialize_json_with_large_dates() {
+        assert_eq!(
+            serde_json::from_str::<Test>(r#""+060056-05-28T05:36:10.955161500Z""#).unwrap(),
+            Test(FileTime::MAX)
+        );
+    }
+}

--- a/src/serde/iso_8601/option.rs
+++ b/src/serde/iso_8601/option.rs
@@ -1,0 +1,198 @@
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (C) 2023 Shun Sakai
+//
+
+//! Use the well-known [ISO 8601 format][iso-8601-description-url] when
+//! serializing and deserializing an [`Option<FileTime>`].
+//!
+//! Use this module in combination with Serde's
+//! [`#[with]`][serde-with-attribute] attribute.
+//!
+//! # Examples
+//!
+//! ```
+//! use nt_time::{serde::iso_8601, FileTime};
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Debug, Deserialize, PartialEq, Serialize)]
+//! struct DateTime(#[serde(with = "iso_8601::option")] Option<FileTime>);
+//!
+//! let json = serde_json::to_string(&DateTime(Some(FileTime::UNIX_EPOCH))).unwrap();
+//! assert_eq!(json, r#""+001970-01-01T00:00:00.000000000Z""#);
+//!
+//! assert_eq!(
+//!     serde_json::from_str::<DateTime>(&json).unwrap(),
+//!     DateTime(Some(FileTime::UNIX_EPOCH))
+//! );
+//!
+//! let json = serde_json::to_string(&DateTime(None)).unwrap();
+//! assert_eq!(json, "null");
+//!
+//! assert_eq!(
+//!     serde_json::from_str::<DateTime>(&json).unwrap(),
+//!     DateTime(None)
+//! );
+//! ```
+//!
+//! [iso-8601-description-url]: https://www.iso.org/iso-8601-date-and-time-format.html
+//! [serde-with-attribute]: https://serde.rs/field-attrs.html#with
+
+use serde::{de::Error as _, ser::Error as _, Deserializer, Serializer};
+use time::serde::iso8601;
+
+use crate::FileTime;
+
+#[allow(clippy::missing_errors_doc)]
+/// Serializes an [`Option<FileTime>`] into the given Serde serializer.
+///
+/// This serializes using the well-known ISO 8601 format.
+pub fn serialize<S: Serializer>(time: &Option<FileTime>, serializer: S) -> Result<S::Ok, S::Error> {
+    (*time)
+        .map(|ft| ft.try_into().map_err(S::Error::custom))
+        .transpose()
+        .and_then(|dt| iso8601::option::serialize(&dt, serializer))
+}
+
+#[allow(clippy::missing_errors_doc)]
+/// Deserializes an [`Option<FileTime>`] from the given Serde deserializer.
+///
+/// This deserializes from its ISO 8601 representation.
+pub fn deserialize<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<FileTime>, D::Error> {
+    iso8601::option::deserialize(deserializer)?
+        .map(|dt| dt.try_into().map_err(D::Error::custom))
+        .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    struct Test(#[serde(with = "crate::serde::iso_8601::option")] Option<FileTime>);
+
+    #[test]
+    fn serde() {
+        assert_tokens(
+            &Test(Some(FileTime::NT_EPOCH)),
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::Some,
+                Token::BorrowedStr("+001601-01-01T00:00:00.000000000Z"),
+            ],
+        );
+        assert_tokens(
+            &Test(Some(FileTime::UNIX_EPOCH)),
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::Some,
+                Token::BorrowedStr("+001970-01-01T00:00:00.000000000Z"),
+            ],
+        );
+        assert_tokens(
+            &Test(None),
+            &[Token::NewtypeStruct { name: "Test" }, Token::None],
+        );
+    }
+
+    #[cfg(feature = "large-dates")]
+    #[test]
+    fn serde_with_large_dates() {
+        assert_tokens(
+            &Test(Some(FileTime::MAX)),
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::Some,
+                Token::BorrowedStr("+060056-05-28T05:36:10.955161500Z"),
+            ],
+        );
+    }
+
+    #[test]
+    fn deserialize_error() {
+        assert_de_tokens_error::<Test>(
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::Some,
+                Token::BorrowedStr("+001600-12-31T23:59:59.999999999Z"),
+            ],
+            "date and time is before `1601-01-01 00:00:00 UTC`",
+        );
+    }
+
+    #[cfg(not(feature = "large-dates"))]
+    #[test]
+    fn deserialize_error_without_large_dates() {
+        assert_de_tokens_error::<Test>(
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::Some,
+                Token::BorrowedStr("+010000-01-01T00:00:00.000000000Z"),
+            ],
+            "year must be in the range -9999..=9999",
+        );
+    }
+
+    #[cfg(feature = "large-dates")]
+    #[test]
+    fn deserialize_error_with_large_dates() {
+        assert_de_tokens_error::<Test>(
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::Some,
+                Token::BorrowedStr("+060056-05-28T05:36:10.955161600Z"),
+            ],
+            "date and time is after `+60056-05-28 05:36:10.955161500 UTC`",
+        );
+    }
+
+    #[test]
+    fn serialize_json() {
+        assert_eq!(
+            serde_json::to_string(&Test(Some(FileTime::NT_EPOCH))).unwrap(),
+            r#""+001601-01-01T00:00:00.000000000Z""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Test(Some(FileTime::UNIX_EPOCH))).unwrap(),
+            r#""+001970-01-01T00:00:00.000000000Z""#
+        );
+        assert_eq!(serde_json::to_string(&Test(None)).unwrap(), "null");
+    }
+
+    #[cfg(feature = "large-dates")]
+    #[test]
+    fn serialize_json_with_large_dates() {
+        assert_eq!(
+            serde_json::to_string(&Test(Some(FileTime::MAX))).unwrap(),
+            r#""+060056-05-28T05:36:10.955161500Z""#
+        );
+    }
+
+    #[test]
+    fn deserialize_json() {
+        assert_eq!(
+            serde_json::from_str::<Test>(r#""1601-01-01T00:00:00Z""#).unwrap(),
+            Test(Some(FileTime::NT_EPOCH))
+        );
+        assert_eq!(
+            serde_json::from_str::<Test>(r#""1970-01-01T00:00:00Z""#).unwrap(),
+            Test(Some(FileTime::UNIX_EPOCH))
+        );
+        assert_eq!(serde_json::from_str::<Test>("null").unwrap(), Test(None));
+    }
+
+    #[cfg(feature = "large-dates")]
+    #[test]
+    fn deserialize_json_with_large_dates() {
+        assert_eq!(
+            serde_json::from_str::<Test>(r#""+060056-05-28T05:36:10.955161500Z""#).unwrap(),
+            Test(Some(FileTime::MAX))
+        );
+    }
+}

--- a/src/serde/iso_8601/option.rs
+++ b/src/serde/iso_8601/option.rs
@@ -10,6 +10,9 @@
 //! Use this module in combination with Serde's
 //! [`#[with]`][serde-with-attribute] attribute.
 //!
+//! If the `large-dates` feature is not enabled, the maximum date and time is
+//! "9999-12-31 23:59:59.999999999 UTC".
+//!
 //! # Examples
 //!
 //! ```

--- a/src/serde/rfc_2822.rs
+++ b/src/serde/rfc_2822.rs
@@ -1,0 +1,105 @@
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (C) 2023 Shun Sakai
+//
+
+//! Use the well-known [RFC 2822 format][rfc-2822] when serializing and
+//! deserializing a [`FileTime`].
+//!
+//! Use this module in combination with Serde's
+//! [`#[with]`][serde-with-attribute] attribute.
+//!
+//! # Examples
+//!
+//! ```
+//! use nt_time::{serde::rfc_2822, FileTime};
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Debug, Deserialize, PartialEq, Serialize)]
+//! struct DateTime(#[serde(with = "rfc_2822")] FileTime);
+//!
+//! let json = serde_json::to_string(&DateTime(FileTime::UNIX_EPOCH)).unwrap();
+//! assert_eq!(json, r#""Thu, 01 Jan 1970 00:00:00 +0000""#);
+//!
+//! assert_eq!(
+//!     serde_json::from_str::<DateTime>(&json).unwrap(),
+//!     DateTime(FileTime::UNIX_EPOCH)
+//! );
+//! ```
+//!
+//! [rfc-2822]: https://datatracker.ietf.org/doc/html/rfc2822#section-3.3
+//! [serde-with-attribute]: https://serde.rs/field-attrs.html#with
+
+pub mod option;
+
+use serde::{de::Error as _, ser::Error as _, Deserializer, Serializer};
+use time::serde::rfc2822;
+
+use crate::FileTime;
+
+#[allow(clippy::missing_errors_doc)]
+/// Serializes a [`FileTime`] into the given Serde serializer.
+///
+/// This serializes using the well-known RFC 2822 format.
+pub fn serialize<S: Serializer>(time: &FileTime, serializer: S) -> Result<S::Ok, S::Error> {
+    (*time)
+        .try_into()
+        .map_err(S::Error::custom)
+        .and_then(|dt| rfc2822::serialize(&dt, serializer))
+}
+
+#[allow(clippy::missing_errors_doc)]
+/// Deserializes a [`FileTime`] from the given Serde deserializer.
+///
+/// This deserializes from its RFC 2822 representation.
+pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<FileTime, D::Error> {
+    rfc2822::deserialize(deserializer).and_then(|dt| dt.try_into().map_err(D::Error::custom))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_test::{assert_ser_tokens_error, assert_tokens, Token};
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    struct Test(#[serde(with = "crate::serde::rfc_2822")] FileTime);
+
+    #[test]
+    fn serde() {
+        assert_tokens(
+            &Test(FileTime::UNIX_EPOCH),
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::BorrowedStr("Thu, 01 Jan 1970 00:00:00 +0000"),
+            ],
+        );
+    }
+
+    #[test]
+    fn serialize_error() {
+        assert_ser_tokens_error::<Test>(
+            &Test(FileTime::NT_EPOCH),
+            &[Token::NewtypeStruct { name: "Test" }],
+            "The year component cannot be formatted into the requested format.",
+        );
+    }
+
+    #[test]
+    fn serialize_json() {
+        assert_eq!(
+            serde_json::to_string(&Test(FileTime::UNIX_EPOCH)).unwrap(),
+            r#""Thu, 01 Jan 1970 00:00:00 +0000""#
+        );
+    }
+
+    #[test]
+    fn deserialize_json() {
+        assert_eq!(
+            serde_json::from_str::<Test>(r#""Thu, 01 Jan 1970 00:00:00 +0000""#).unwrap(),
+            Test(FileTime::UNIX_EPOCH)
+        );
+    }
+}

--- a/src/serde/rfc_2822/option.rs
+++ b/src/serde/rfc_2822/option.rs
@@ -1,0 +1,122 @@
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (C) 2023 Shun Sakai
+//
+
+//! Use the well-known [RFC 2822 format][rfc-2822] when serializing and
+//! deserializing an [`Option<FileTime>`].
+//!
+//! Use this module in combination with Serde's
+//! [`#[with]`][serde-with-attribute] attribute.
+//!
+//! # Examples
+//!
+//! ```
+//! use nt_time::{serde::rfc_2822, FileTime};
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Debug, Deserialize, PartialEq, Serialize)]
+//! struct DateTime(#[serde(with = "rfc_2822::option")] Option<FileTime>);
+//!
+//! let json = serde_json::to_string(&DateTime(Some(FileTime::UNIX_EPOCH))).unwrap();
+//! assert_eq!(json, r#""Thu, 01 Jan 1970 00:00:00 +0000""#);
+//!
+//! assert_eq!(
+//!     serde_json::from_str::<DateTime>(&json).unwrap(),
+//!     DateTime(Some(FileTime::UNIX_EPOCH))
+//! );
+//!
+//! let json = serde_json::to_string(&DateTime(None)).unwrap();
+//! assert_eq!(json, "null");
+//!
+//! assert_eq!(
+//!     serde_json::from_str::<DateTime>(&json).unwrap(),
+//!     DateTime(None)
+//! );
+//! ```
+//!
+//! [rfc-2822]: https://datatracker.ietf.org/doc/html/rfc2822#section-3.3
+//! [serde-with-attribute]: https://serde.rs/field-attrs.html#with
+
+use serde::{de::Error as _, ser::Error as _, Deserializer, Serializer};
+use time::serde::rfc2822;
+
+use crate::FileTime;
+
+#[allow(clippy::missing_errors_doc)]
+/// Serializes an [`Option<FileTime>`] into the given Serde serializer.
+///
+/// This serializes using the well-known RFC 2822 format.
+pub fn serialize<S: Serializer>(time: &Option<FileTime>, serializer: S) -> Result<S::Ok, S::Error> {
+    (*time)
+        .map(|ft| ft.try_into().map_err(S::Error::custom))
+        .transpose()
+        .and_then(|dt| rfc2822::option::serialize(&dt, serializer))
+}
+
+#[allow(clippy::missing_errors_doc)]
+/// Deserializes an [`Option<FileTime>`] from the given Serde deserializer.
+///
+/// This deserializes from its RFC 2822 representation.
+pub fn deserialize<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<FileTime>, D::Error> {
+    rfc2822::option::deserialize(deserializer)?
+        .map(|dt| dt.try_into().map_err(D::Error::custom))
+        .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_test::{assert_ser_tokens_error, assert_tokens, Token};
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    struct Test(#[serde(with = "crate::serde::rfc_2822::option")] Option<FileTime>);
+
+    #[test]
+    fn serde() {
+        assert_tokens(
+            &Test(Some(FileTime::UNIX_EPOCH)),
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::Some,
+                Token::BorrowedStr("Thu, 01 Jan 1970 00:00:00 +0000"),
+            ],
+        );
+        assert_tokens(
+            &Test(None),
+            &[Token::NewtypeStruct { name: "Test" }, Token::None],
+        );
+    }
+
+    #[test]
+    fn serialize_error() {
+        assert_ser_tokens_error::<Test>(
+            &Test(Some(FileTime::NT_EPOCH)),
+            &[Token::NewtypeStruct { name: "Test" }],
+            "The year component cannot be formatted into the requested format.",
+        );
+    }
+
+    #[test]
+    fn serialize_json() {
+        assert_eq!(
+            serde_json::to_string(&Test(Some(FileTime::UNIX_EPOCH))).unwrap(),
+            r#""Thu, 01 Jan 1970 00:00:00 +0000""#
+        );
+        assert_eq!(serde_json::to_string(&Test(None)).unwrap(), "null");
+    }
+
+    #[test]
+    fn deserialize_json() {
+        assert_eq!(
+            serde_json::from_str::<Test>(r#""Thu, 01 Jan 1970 00:00:00 +0000""#).unwrap(),
+            Test(Some(FileTime::UNIX_EPOCH))
+        );
+        assert_eq!(serde_json::from_str::<Test>("null").unwrap(), Test(None));
+    }
+}

--- a/src/serde/rfc_3339.rs
+++ b/src/serde/rfc_3339.rs
@@ -1,0 +1,142 @@
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (C) 2023 Shun Sakai
+//
+
+//! Use the well-known [RFC 3339 format][rfc-3339] when serializing and
+//! deserializing a [`FileTime`].
+//!
+//! Use this module in combination with Serde's
+//! [`#[with]`][serde-with-attribute] attribute.
+//!
+//! # Examples
+//!
+//! ```
+//! use nt_time::{serde::rfc_3339, FileTime};
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Debug, Deserialize, PartialEq, Serialize)]
+//! struct DateTime(#[serde(with = "rfc_3339")] FileTime);
+//!
+//! let json = serde_json::to_string(&DateTime(FileTime::UNIX_EPOCH)).unwrap();
+//! assert_eq!(json, r#""1970-01-01T00:00:00Z""#);
+//!
+//! assert_eq!(
+//!     serde_json::from_str::<DateTime>(&json).unwrap(),
+//!     DateTime(FileTime::UNIX_EPOCH)
+//! );
+//! ```
+//!
+//! [rfc-3339]: https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+//! [serde-with-attribute]: https://serde.rs/field-attrs.html#with
+
+pub mod option;
+
+use serde::{de::Error as _, ser::Error as _, Deserializer, Serializer};
+use time::serde::rfc3339;
+
+use crate::FileTime;
+
+#[allow(clippy::missing_errors_doc)]
+/// Serializes a [`FileTime`] into the given Serde serializer.
+///
+/// This serializes using the well-known RFC 3339 format.
+pub fn serialize<S: Serializer>(time: &FileTime, serializer: S) -> Result<S::Ok, S::Error> {
+    (*time)
+        .try_into()
+        .map_err(S::Error::custom)
+        .and_then(|dt| rfc3339::serialize(&dt, serializer))
+}
+
+#[allow(clippy::missing_errors_doc)]
+/// Deserializes a [`FileTime`] from the given Serde deserializer.
+///
+/// This deserializes from its RFC 3339 representation.
+pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<FileTime, D::Error> {
+    rfc3339::deserialize(deserializer).and_then(|dt| dt.try_into().map_err(D::Error::custom))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_test::{assert_de_tokens_error, assert_ser_tokens_error, assert_tokens, Token};
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    struct Test(#[serde(with = "crate::serde::rfc_3339")] FileTime);
+
+    #[test]
+    fn serde() {
+        assert_tokens(
+            &Test(FileTime::NT_EPOCH),
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::BorrowedStr("1601-01-01T00:00:00Z"),
+            ],
+        );
+        assert_tokens(
+            &Test(FileTime::UNIX_EPOCH),
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::BorrowedStr("1970-01-01T00:00:00Z"),
+            ],
+        );
+    }
+
+    #[cfg(not(feature = "large-dates"))]
+    #[test]
+    fn serialize_error_without_large_dates() {
+        assert_ser_tokens_error::<Test>(
+            &Test(FileTime::MAX),
+            &[Token::NewtypeStruct { name: "Test" }],
+            "date and time is out of range for `OffsetDateTime`",
+        );
+    }
+
+    #[cfg(feature = "large-dates")]
+    #[test]
+    fn serialize_error_with_large_dates() {
+        assert_ser_tokens_error::<Test>(
+            &Test(FileTime::MAX),
+            &[Token::NewtypeStruct { name: "Test" }],
+            "The year component cannot be formatted into the requested format.",
+        );
+    }
+
+    #[test]
+    fn deserialize_error() {
+        assert_de_tokens_error::<Test>(
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::BorrowedStr("1600-12-31T23:59:59.999999999Z"),
+            ],
+            "date and time is before `1601-01-01 00:00:00 UTC`",
+        );
+    }
+
+    #[test]
+    fn serialize_json() {
+        assert_eq!(
+            serde_json::to_string(&Test(FileTime::NT_EPOCH)).unwrap(),
+            r#""1601-01-01T00:00:00Z""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Test(FileTime::UNIX_EPOCH)).unwrap(),
+            r#""1970-01-01T00:00:00Z""#
+        );
+    }
+
+    #[test]
+    fn deserialize_json() {
+        assert_eq!(
+            serde_json::from_str::<Test>(r#""1601-01-01T00:00:00Z""#).unwrap(),
+            Test(FileTime::NT_EPOCH)
+        );
+        assert_eq!(
+            serde_json::from_str::<Test>(r#""1970-01-01T00:00:00Z""#).unwrap(),
+            Test(FileTime::UNIX_EPOCH)
+        );
+    }
+}

--- a/src/serde/rfc_3339/option.rs
+++ b/src/serde/rfc_3339/option.rs
@@ -1,0 +1,161 @@
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (C) 2023 Shun Sakai
+//
+
+//! Use the well-known [RFC 3339 format][rfc-3339] when serializing and
+//! deserializing an [`Option<FileTime>`].
+//!
+//! Use this module in combination with Serde's
+//! [`#[with]`][serde-with-attribute] attribute.
+//!
+//! # Examples
+//!
+//! ```
+//! use nt_time::{serde::rfc_3339, FileTime};
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Debug, Deserialize, PartialEq, Serialize)]
+//! struct DateTime(#[serde(with = "rfc_3339::option")] Option<FileTime>);
+//!
+//! let json = serde_json::to_string(&DateTime(Some(FileTime::UNIX_EPOCH))).unwrap();
+//! assert_eq!(json, r#""1970-01-01T00:00:00Z""#);
+//!
+//! assert_eq!(
+//!     serde_json::from_str::<DateTime>(&json).unwrap(),
+//!     DateTime(Some(FileTime::UNIX_EPOCH))
+//! );
+//!
+//! let json = serde_json::to_string(&DateTime(None)).unwrap();
+//! assert_eq!(json, "null");
+//!
+//! assert_eq!(
+//!     serde_json::from_str::<DateTime>(&json).unwrap(),
+//!     DateTime(None)
+//! );
+//! ```
+//!
+//! [rfc-3339]: https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+//! [serde-with-attribute]: https://serde.rs/field-attrs.html#with
+
+use serde::{de::Error as _, ser::Error as _, Deserializer, Serializer};
+use time::serde::rfc3339;
+
+use crate::FileTime;
+
+#[allow(clippy::missing_errors_doc)]
+/// Serializes an [`Option<FileTime>`] into the given Serde serializer.
+///
+/// This serializes using the well-known RFC 3339 format.
+pub fn serialize<S: Serializer>(time: &Option<FileTime>, serializer: S) -> Result<S::Ok, S::Error> {
+    (*time)
+        .map(|ft| ft.try_into().map_err(S::Error::custom))
+        .transpose()
+        .and_then(|dt| rfc3339::option::serialize(&dt, serializer))
+}
+
+#[allow(clippy::missing_errors_doc)]
+/// Deserializes an [`Option<FileTime>`] from the given Serde deserializer.
+///
+/// This deserializes from its RFC 3339 representation.
+pub fn deserialize<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<FileTime>, D::Error> {
+    rfc3339::option::deserialize(deserializer)?
+        .map(|dt| dt.try_into().map_err(D::Error::custom))
+        .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_test::{assert_de_tokens_error, assert_ser_tokens_error, assert_tokens, Token};
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize)]
+    struct Test(#[serde(with = "crate::serde::rfc_3339::option")] Option<FileTime>);
+
+    #[test]
+    fn serde() {
+        assert_tokens(
+            &Test(Some(FileTime::NT_EPOCH)),
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::Some,
+                Token::BorrowedStr("1601-01-01T00:00:00Z"),
+            ],
+        );
+        assert_tokens(
+            &Test(Some(FileTime::UNIX_EPOCH)),
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::Some,
+                Token::BorrowedStr("1970-01-01T00:00:00Z"),
+            ],
+        );
+        assert_tokens(
+            &Test(None),
+            &[Token::NewtypeStruct { name: "Test" }, Token::None],
+        );
+    }
+
+    #[cfg(not(feature = "large-dates"))]
+    #[test]
+    fn serialize_error_without_large_dates() {
+        assert_ser_tokens_error::<Test>(
+            &Test(Some(FileTime::MAX)),
+            &[Token::NewtypeStruct { name: "Test" }],
+            "date and time is out of range for `OffsetDateTime`",
+        );
+    }
+
+    #[cfg(feature = "large-dates")]
+    #[test]
+    fn serialize_error_with_large_dates() {
+        assert_ser_tokens_error::<Test>(
+            &Test(Some(FileTime::MAX)),
+            &[Token::NewtypeStruct { name: "Test" }],
+            "The year component cannot be formatted into the requested format.",
+        );
+    }
+
+    #[test]
+    fn deserialize_error() {
+        assert_de_tokens_error::<Test>(
+            &[
+                Token::NewtypeStruct { name: "Test" },
+                Token::Some,
+                Token::BorrowedStr("1600-12-31T23:59:59.999999999Z"),
+            ],
+            "date and time is before `1601-01-01 00:00:00 UTC`",
+        );
+    }
+
+    #[test]
+    fn serialize_json() {
+        assert_eq!(
+            serde_json::to_string(&Test(Some(FileTime::NT_EPOCH))).unwrap(),
+            r#""1601-01-01T00:00:00Z""#
+        );
+        assert_eq!(
+            serde_json::to_string(&Test(Some(FileTime::UNIX_EPOCH))).unwrap(),
+            r#""1970-01-01T00:00:00Z""#
+        );
+        assert_eq!(serde_json::to_string(&Test(None)).unwrap(), "null");
+    }
+
+    #[test]
+    fn deserialize_json() {
+        assert_eq!(
+            serde_json::from_str::<Test>(r#""1601-01-01T00:00:00Z""#).unwrap(),
+            Test(Some(FileTime::NT_EPOCH))
+        );
+        assert_eq!(
+            serde_json::from_str::<Test>(r#""1970-01-01T00:00:00Z""#).unwrap(),
+            Test(Some(FileTime::UNIX_EPOCH))
+        );
+        assert_eq!(serde_json::from_str::<Test>("null").unwrap(), Test(None));
+    }
+}


### PR DESCRIPTION
- Serializes a `FileTime` into the underlying 64-bit unsigned integer format.
- Deserializes a `FileTime` from the underlying 64-bit unsigned integer format.
- Serializes a `FileTime` into ISO 8601, RFC 2822 and RFC 3339 formats.
- Deserializes a `FileTime` from ISO 8601, RFC 2822 and RFC 3339 formats.