### PR TITLE
Update copyright notice

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,13 @@ project adheres to https://semver.org/[Semantic Versioning].
 
 toc::[]
 
+== {compare-url}/v0.5.0\...HEAD[Unreleased]
+
+=== Changed
+
+* Change the comment header to the format recommended by the REUSE
+  Specification ({pull-request-url}/22[#22])
+
 == {compare-url}/v0.4.1\...v0.5.0[0.5.0] - 2023-05-15
 
 === Added

--- a/examples/date.rs
+++ b/examples/date.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! An example of printing the file time.
 

--- a/examples/ft2unix.rs
+++ b/examples/ft2unix.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! An example of converting the file time to Unix time.
 

--- a/examples/unix2ft.rs
+++ b/examples/unix2ft.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! An example of converting Unix time to the file time.
 

--- a/justfile
+++ b/justfile
@@ -1,8 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Shun Sakai
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-# Copyright (C) 2023 Shun Sakai
-#
 
 alias all := default
 alias lint := clippy

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! Error types for this crate.
 

--- a/src/file_time.rs
+++ b/src/file_time.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! A [Windows file time][file-time-docs-url].
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! The `nt-time` crate is a [Windows file time][file-time-docs-url] library.
 //!

--- a/src/serde_with.rs
+++ b/src/serde_with.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! Differential formats for [Serde][serde-official-url].
 //!

--- a/src/serde_with/iso_8601.rs
+++ b/src/serde_with/iso_8601.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! Use the well-known [ISO 8601 format][iso-8601-description-url] when
 //! serializing and deserializing a [`FileTime`].

--- a/src/serde_with/iso_8601/option.rs
+++ b/src/serde_with/iso_8601/option.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! Use the well-known [ISO 8601 format][iso-8601-description-url] when
 //! serializing and deserializing an [`Option<FileTime>`].

--- a/src/serde_with/rfc_2822.rs
+++ b/src/serde_with/rfc_2822.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! Use the well-known [RFC 2822 format][rfc-2822] when serializing and
 //! deserializing a [`FileTime`].

--- a/src/serde_with/rfc_2822/option.rs
+++ b/src/serde_with/rfc_2822/option.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! Use the well-known [RFC 2822 format][rfc-2822] when serializing and
 //! deserializing an [`Option<FileTime>`].

--- a/src/serde_with/rfc_3339.rs
+++ b/src/serde_with/rfc_3339.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! Use the well-known [RFC 3339 format][rfc-3339] when serializing and
 //! deserializing a [`FileTime`].

--- a/src/serde_with/rfc_3339/option.rs
+++ b/src/serde_with/rfc_3339/option.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! Use the well-known [RFC 3339 format][rfc-3339] when serializing and
 //! deserializing an [`Option<FileTime>`].

--- a/src/serde_with/unix_time.rs
+++ b/src/serde_with/unix_time.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! Use Unix time when serializing and deserializing a [`FileTime`].
 //!

--- a/src/serde_with/unix_time/option.rs
+++ b/src/serde_with/unix_time/option.rs
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! Use Unix time when serializing and deserializing an [`Option<FileTime>`].
 //!


### PR DESCRIPTION
Change the comment header to the format recommended by the REUSE Specification.[^1]

[^1]: https://reuse.software/spec/#comment-headers