### PR TITLE
Update version to 0.5.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.5.1
 
 [bumpversion:file:Cargo.toml]
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,7 +16,7 @@ project adheres to https://semver.org/[Semantic Versioning].
 
 toc::[]
 
-== {compare-url}/v0.5.0\...HEAD[Unreleased]
+== {compare-url}/v0.5.0\...v0.5.1[0.5.1] - 2023-08-01
 
 === Changed
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,7 @@ toc::[]
 * Change the comment header to the format recommended by the REUSE
   Specification ({pull-request-url}/22[#22])
 * Make this project REUSE compliant ({pull-request-url}/23[#23])
+* Pin the version of `time` crate to 0.3.23 ({pull-request-url}/172[#172])
 
 == {compare-url}/v0.4.1\...v0.5.0[0.5.0] - 2023-05-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ exclude = [
 [dependencies]
 chrono = { version = "0.4.24", default-features = false, optional = true }
 serde = { version = "1.0.160", default-features = false, features = ["derive"], optional = true }
-time = { version = "0.3.21", default-features = false, features = ["macros"] }
+time = { version = "=0.3.23", default-features = false, features = ["macros"] }
 
 [dev-dependencies]
 anyhow = "1.0.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "nt-time"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Shun Sakai <sorairolake@protonmail.ch>"]
 edition = "2021"
 rust-version = "1.65.0"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-nt-time = "0.5.0"
+nt-time = "0.5.1"
 ```
 
 ### Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! [file-time-docs-url]: https://docs.microsoft.com/en-us/windows/win32/sysinfo/file-times
 //! [7z-format-url]: https://www.7-zip.org/7z.html
 
-#![doc(html_root_url = "https://docs.rs/nt-time/0.5.0/")]
+#![doc(html_root_url = "https://docs.rs/nt-time/0.5.1/")]
 #![no_std]
 #![cfg_attr(doc_cfg, feature(doc_auto_cfg, doc_cfg))]
 // Lint levels of rustc.


### PR DESCRIPTION
Also, pin the version of `time` crate to 0.3.23. This is for keep the MSRV.