### PR TITLE
Add methods to convert `FileTime` from/to `i64`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,7 @@ project adheres to https://semver.org/[Semantic Versioning].
 * Implement `fmt::Octal`, `fmt::LowerHex`, `fmt::UpperHex`, `fmt::Binary`,
   `fmt::LowerExp` and `fmt::UpperExp` for `FileTime`
   ({pull-request-url}/75[#75])
+* Add conversion methods from/to `i64` ({pull-request-url}/76[#76])
 
 == {compare-url}/v0.6.1\...v0.6.2[0.6.2] - 2023-11-24
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
The file time may be represented as an `i64` value in WinRT, .NET, etc.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->
See also #58.

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
