### PR TITLE
Fix conversion from/to MS-DOS date and time

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,12 @@ project adheres to https://semver.org/[Semantic Versioning].
 
 * Implement `FromStr` for `FileTime` ({pull-request-url}/80[#80])
 
+=== Fixed
+
+* Fix `FileTime::to_dos_date_time` and `FileTime::from_dos_date_time` to return
+  `None` as the UTC offset if the number of seconds of the UTC offset is not
+  zero ({pull-request-url}/81[#81])
+
 == {compare-url}/v0.6.2\...v0.6.3[0.6.3] - 2023-11-26
 
 === Added


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Fix `FileTime::to_dos_date_time` and `FileTime::from_dos_date_time` to return `None` as the UTC offset if the number of seconds of the UTC offset is not zero.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
