### PR TITLE
Change to use `TimeDelta::seconds`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,13 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/v0.6.10\...HEAD[Unreleased]
+
+=== Changed
+
+* Use `TimeDelta::seconds` instead of `TimeDelta::try_seconds`
+  ({pull-request-url}/151[#151])
+
 == {compare-url}/v0.6.9\...v0.6.10[0.6.10] - 2024-04-08
 
 === Changed

--- a/src/file_time.rs
+++ b/src/file_time.rs
@@ -1483,15 +1483,13 @@ impl From<FileTime> for chrono::DateTime<chrono::Utc> {
     fn from(ft: FileTime) -> Self {
         use chrono::TimeDelta;
 
-        let duration = TimeDelta::try_seconds(
+        let duration = TimeDelta::seconds(
             i64::try_from(ft.to_raw() / FILE_TIMES_PER_SEC)
                 .expect("the number of seconds should be in the range of `i64`"),
-        )
-        .expect("the number of seconds should be in the range of `TimeDelta`")
-            + TimeDelta::nanoseconds(
-                i64::try_from((ft.to_raw() % FILE_TIMES_PER_SEC) * 100)
-                    .expect("the number of nanoseconds should be in the range of `i64`"),
-            );
+        ) + TimeDelta::nanoseconds(
+            i64::try_from((ft.to_raw() % FILE_TIMES_PER_SEC) * 100)
+                .expect("the number of nanoseconds should be in the range of `i64`"),
+        );
         "1601-01-01 00:00:00 UTC"
             .parse::<Self>()
             .expect("date and time should be valid as RFC 3339")


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
