### PR TITLE
Add `From<FileTime> for OffsetDateTime`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,26 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/v0.6.13\...HEAD[Unreleased]
+
+=== Added
+
+* Add `From<FileTime> for OffsetDateTime` for when the `large-dates` feature is
+  enabled ({pull-request-url}/167[#167])
+
+=== Changed
+
+* When the `large-dates` feature is enabled, change to use
+  `From<FileTime> for OffsetDateTime` instead of
+  `TryFrom<FileTime> for OffsetDateTime` ({pull-request-url}/167[#167])
+* Change `TryFrom<FileTime> for OffsetDateTime` to return
+  `time::error::ComponentRange` instead of `OffsetDateTimeRangeError`
+  ({pull-request-url}/167[#167])
+
+=== Removed
+
+* Remove `OffsetDateTimeRangeError` ({pull-request-url}/167[#167])
+
 == {compare-url}/v0.6.12\...v0.6.13[0.6.13] - 2024-05-24
 
 === Fixed

--- a/examples/date.rs
+++ b/examples/date.rs
@@ -11,7 +11,6 @@
 // Lint levels of Clippy.
 #![warn(clippy::cargo, clippy::nursery, clippy::pedantic)]
 
-use anyhow::Context;
 use clap::Parser;
 use nt_time::{time::OffsetDateTime, FileTime};
 
@@ -22,10 +21,21 @@ struct Opt {
     time: FileTime,
 }
 
+#[cfg(not(feature = "large-dates"))]
 fn main() -> anyhow::Result<()> {
+    use anyhow::Context;
+
     let opt = Opt::parse();
 
     let dt = OffsetDateTime::try_from(opt.time).context("could not convert time")?;
     println!("{dt}");
     Ok(())
+}
+
+#[cfg(feature = "large-dates")]
+fn main() {
+    let opt = Opt::parse();
+
+    let dt = OffsetDateTime::from(opt.time);
+    println!("{dt}");
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,22 +88,6 @@ impl fmt::Display for DosDateTimeRangeErrorKind {
     }
 }
 
-/// The error type indicating that a [`OffsetDateTime`](time::OffsetDateTime)
-/// was out of range.
-#[allow(clippy::module_name_repetitions)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct OffsetDateTimeRangeError;
-
-impl fmt::Display for OffsetDateTimeRangeError {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "date and time is out of range for `OffsetDateTime`")
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for OffsetDateTimeRangeError {}
-
 /// The error type indicating that a [`FileTime`](crate::FileTime) was out of
 /// range.
 #[allow(clippy::module_name_repetitions)]
@@ -403,47 +387,6 @@ mod tests {
             format!("{}", DosDateTimeRangeErrorKind::Overflow),
             "date and time is after `2107-12-31 23:59:59.990000000`"
         );
-    }
-
-    #[test]
-    fn clone_offset_date_time_range_error() {
-        assert_eq!(OffsetDateTimeRangeError.clone(), OffsetDateTimeRangeError);
-    }
-
-    #[test]
-    fn copy_offset_date_time_range_error() {
-        let a = OffsetDateTimeRangeError;
-        let b = a;
-        assert_eq!(a, b);
-    }
-
-    #[test]
-    fn debug_offset_date_time_range_error() {
-        assert_eq!(
-            format!("{OffsetDateTimeRangeError:?}"),
-            "OffsetDateTimeRangeError"
-        );
-    }
-
-    #[test]
-    fn offset_date_time_range_error_equality() {
-        assert_eq!(OffsetDateTimeRangeError, OffsetDateTimeRangeError);
-    }
-
-    #[test]
-    fn display_offset_date_time_range_error() {
-        assert_eq!(
-            format!("{OffsetDateTimeRangeError}"),
-            "date and time is out of range for `OffsetDateTime`"
-        );
-    }
-
-    #[cfg(feature = "std")]
-    #[test]
-    fn source_offset_date_time_range_error() {
-        use std::error::Error;
-
-        assert!(OffsetDateTimeRangeError.source().is_none());
     }
 
     #[test]

--- a/src/file_time/cmp.rs
+++ b/src/file_time/cmp.rs
@@ -31,15 +31,23 @@ impl PartialEq<std::time::SystemTime> for FileTime {
 impl PartialEq<FileTime> for OffsetDateTime {
     #[inline]
     fn eq(&self, other: &FileTime) -> bool {
-        self == &Self::try_from(*other).expect("`other` is out of range for `OffsetDateTime`")
+        #[cfg(not(feature = "large-dates"))]
+        let other = Self::try_from(*other).expect("`other` is out of range for `OffsetDateTime`");
+        #[cfg(feature = "large-dates")]
+        let other = Self::from(*other);
+        self == &other
     }
 }
 
 impl PartialEq<OffsetDateTime> for FileTime {
     #[inline]
     fn eq(&self, other: &OffsetDateTime) -> bool {
-        &OffsetDateTime::try_from(*self).expect("`self` is out of range for `OffsetDateTime`")
-            == other
+        #[cfg(not(feature = "large-dates"))]
+        let dt =
+            OffsetDateTime::try_from(*self).expect("`self` is out of range for `OffsetDateTime`");
+        #[cfg(feature = "large-dates")]
+        let dt = OffsetDateTime::from(*self);
+        &dt == other
     }
 }
 
@@ -98,18 +106,23 @@ impl PartialOrd<std::time::SystemTime> for FileTime {
 impl PartialOrd<FileTime> for OffsetDateTime {
     #[inline]
     fn partial_cmp(&self, other: &FileTime) -> Option<Ordering> {
-        self.partial_cmp(
-            &Self::try_from(*other).expect("`other` is out of range for `OffsetDateTime`"),
-        )
+        #[cfg(not(feature = "large-dates"))]
+        let other = Self::try_from(*other).expect("`other` is out of range for `OffsetDateTime`");
+        #[cfg(feature = "large-dates")]
+        let other = Self::from(*other);
+        self.partial_cmp(&other)
     }
 }
 
 impl PartialOrd<OffsetDateTime> for FileTime {
     #[inline]
     fn partial_cmp(&self, other: &OffsetDateTime) -> Option<Ordering> {
-        OffsetDateTime::try_from(*self)
-            .expect("`self` is out of range for `OffsetDateTime`")
-            .partial_cmp(other)
+        #[cfg(not(feature = "large-dates"))]
+        let dt =
+            OffsetDateTime::try_from(*self).expect("`self` is out of range for `OffsetDateTime`");
+        #[cfg(feature = "large-dates")]
+        let dt = OffsetDateTime::from(*self);
+        dt.partial_cmp(other)
     }
 }
 

--- a/src/file_time/convert.rs
+++ b/src/file_time/convert.rs
@@ -6,11 +6,11 @@
 
 use core::num::TryFromIntError;
 
-use time::{macros::datetime, OffsetDateTime};
+use time::OffsetDateTime;
 
-use crate::error::{FileTimeRangeError, FileTimeRangeErrorKind, OffsetDateTimeRangeError};
+use crate::error::{FileTimeRangeError, FileTimeRangeErrorKind};
 
-use super::{FileTime, FILE_TIMES_PER_SEC};
+use super::FileTime;
 
 impl From<FileTime> for u64 {
     /// Converts a `FileTime` to the file time.
@@ -104,6 +104,8 @@ impl From<FileTime> for std::time::SystemTime {
     fn from(ft: FileTime) -> Self {
         use std::time::Duration;
 
+        use super::FILE_TIMES_PER_SEC;
+
         let duration = Duration::new(
             ft.to_raw() / FILE_TIMES_PER_SEC,
             u32::try_from((ft.to_raw() % FILE_TIMES_PER_SEC) * 100)
@@ -113,8 +115,9 @@ impl From<FileTime> for std::time::SystemTime {
     }
 }
 
+#[cfg(not(feature = "large-dates"))]
 impl TryFrom<FileTime> for OffsetDateTime {
-    type Error = OffsetDateTimeRangeError;
+    type Error = time::error::ComponentRange;
 
     /// Converts a `FileTime` to a [`OffsetDateTime`].
     ///
@@ -138,19 +141,20 @@ impl TryFrom<FileTime> for OffsetDateTime {
     ///     OffsetDateTime::try_from(FileTime::UNIX_EPOCH).unwrap(),
     ///     OffsetDateTime::UNIX_EPOCH
     /// );
-    /// ```
     ///
-    /// With the `large-dates` feature disabled, returns [`Err`] if the file
-    /// time represents after "9999-12-31 23:59:59.999999900 UTC":
-    ///
-    /// ```
-    /// # use nt_time::{time::OffsetDateTime, FileTime};
-    /// #
-    /// # #[cfg(not(feature = "large-dates"))]
+    /// // After `9999-12-31 23:59:59.999999900 UTC`.
     /// assert!(OffsetDateTime::try_from(FileTime::new(2_650_467_744_000_000_000)).is_err());
     /// ```
+    fn try_from(ft: FileTime) -> Result<Self, Self::Error> {
+        Self::from_unix_timestamp_nanos(ft.to_unix_time_nanos())
+    }
+}
+
+#[cfg(feature = "large-dates")]
+impl From<FileTime> for OffsetDateTime {
+    /// Converts a `FileTime` to a [`OffsetDateTime`].
     ///
-    /// With the `large-dates` feature enabled, this always succeeds:
+    /// # Examples
     ///
     /// ```
     /// # use nt_time::{
@@ -158,29 +162,22 @@ impl TryFrom<FileTime> for OffsetDateTime {
     /// #     FileTime,
     /// # };
     /// #
-    /// # #[cfg(feature = "large-dates")]
     /// assert_eq!(
-    ///     OffsetDateTime::try_from(FileTime::new(2_650_467_744_000_000_000)).unwrap(),
-    ///     datetime!(+10000-01-01 00:00 UTC)
+    ///     OffsetDateTime::from(FileTime::NT_TIME_EPOCH),
+    ///     datetime!(1601-01-01 00:00 UTC)
     /// );
-    /// # #[cfg(feature = "large-dates")]
     /// assert_eq!(
-    ///     OffsetDateTime::try_from(FileTime::MAX).unwrap(),
+    ///     OffsetDateTime::from(FileTime::UNIX_EPOCH),
+    ///     OffsetDateTime::UNIX_EPOCH
+    /// );
+    /// assert_eq!(
+    ///     OffsetDateTime::from(FileTime::MAX),
     ///     datetime!(+60056-05-28 05:36:10.955_161_500 UTC)
     /// );
     /// ```
-    fn try_from(ft: FileTime) -> Result<Self, Self::Error> {
-        use time::Duration;
-
-        let duration = Duration::new(
-            i64::try_from(ft.to_raw() / FILE_TIMES_PER_SEC)
-                .expect("the number of seconds should be in the range of `i64`"),
-            i32::try_from((ft.to_raw() % FILE_TIMES_PER_SEC) * 100)
-                .expect("the number of nanoseconds should be in the range of `i32`"),
-        );
-        datetime!(1601-01-01 00:00 UTC)
-            .checked_add(duration)
-            .ok_or(OffsetDateTimeRangeError)
+    fn from(ft: FileTime) -> Self {
+        Self::from_unix_timestamp_nanos(ft.to_unix_time_nanos())
+            .expect("date and time should be in the range of `OffsetDateTime`")
     }
 }
 
@@ -206,19 +203,14 @@ impl From<FileTime> for chrono::DateTime<chrono::Utc> {
     /// );
     /// ```
     fn from(ft: FileTime) -> Self {
-        use chrono::TimeDelta;
-
-        let duration = TimeDelta::seconds(
-            i64::try_from(ft.to_raw() / FILE_TIMES_PER_SEC)
+        let ut = ft.to_unix_time_nanos();
+        Self::from_timestamp(
+            i64::try_from(ut / 1_000_000_000)
                 .expect("the number of seconds should be in the range of `i64`"),
-        ) + TimeDelta::nanoseconds(
-            i64::try_from((ft.to_raw() % FILE_TIMES_PER_SEC) * 100)
-                .expect("the number of nanoseconds should be in the range of `i64`"),
-        );
-        "1601-01-01 00:00:00 UTC"
-            .parse::<Self>()
-            .expect("date and time should be valid as RFC 3339")
-            + duration
+            u32::try_from(ut % 1_000_000_000)
+                .expect("the number of nanoseconds should be in the range of `u32`"),
+        )
+        .expect("Unix time in nanoseconds should be in the range of `DateTime<Utc>`")
     }
 }
 
@@ -434,7 +426,9 @@ impl TryFrom<OffsetDateTime> for FileTime {
     /// );
     ///
     /// // Before `1601-01-01 00:00:00 UTC`.
-    /// assert!(FileTime::try_from(datetime!(1601-01-01 00:00 UTC) - Duration::NANOSECOND).is_err());
+    /// assert!(
+    ///     FileTime::try_from(datetime!(1601-01-01 00:00 UTC) - Duration::nanoseconds(100)).is_err()
+    /// );
     /// ```
     ///
     /// With the `large-dates` feature enabled, returns [`Err`] if
@@ -454,14 +448,7 @@ impl TryFrom<OffsetDateTime> for FileTime {
     /// .is_err());
     /// ```
     fn try_from(dt: OffsetDateTime) -> Result<Self, Self::Error> {
-        use core::time::Duration;
-
-        let elapsed = Duration::try_from(dt - datetime!(1601-01-01 00:00 UTC))
-            .map(|d| d.as_nanos())
-            .map_err(|_| Self::Error::new(FileTimeRangeErrorKind::Negative))?;
-        let ft = u64::try_from(elapsed / 100)
-            .map_err(|_| Self::Error::new(FileTimeRangeErrorKind::Overflow))?;
-        Ok(Self::new(ft))
+        Self::from_unix_time_nanos(dt.unix_timestamp_nanos())
     }
 }
 
@@ -494,7 +481,7 @@ impl TryFrom<chrono::DateTime<chrono::Utc>> for FileTime {
     ///
     /// // Before `1601-01-01 00:00:00 UTC`.
     /// assert!(FileTime::try_from(
-    ///     Utc.with_ymd_and_hms(1601, 1, 1, 0, 0, 0).unwrap() - TimeDelta::nanoseconds(1)
+    ///     Utc.with_ymd_and_hms(1601, 1, 1, 0, 0, 0).unwrap() - TimeDelta::nanoseconds(100)
     /// )
     /// .is_err());
     ///
@@ -507,18 +494,9 @@ impl TryFrom<chrono::DateTime<chrono::Utc>> for FileTime {
     /// .is_err());
     /// ```
     fn try_from(dt: chrono::DateTime<chrono::Utc>) -> Result<Self, Self::Error> {
-        use chrono::{DateTime, Utc};
-
-        let elapsed = (dt
-            - "1601-01-01 00:00:00 UTC"
-                .parse::<DateTime<Utc>>()
-                .expect("date and time should be valid as RFC 3339"))
-        .to_std()
-        .map(|d| d.as_nanos())
-        .map_err(|_| Self::Error::new(FileTimeRangeErrorKind::Negative))?;
-        let ft = u64::try_from(elapsed / 100)
-            .map_err(|_| Self::Error::new(FileTimeRangeErrorKind::Overflow))?;
-        Ok(Self::new(ft))
+        let ut =
+            (i128::from(dt.timestamp()) * 1_000_000_000) + i128::from(dt.timestamp_subsec_nanos());
+        Self::from_unix_time_nanos(ut)
     }
 }
 
@@ -621,8 +599,11 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "large-dates"))]
     #[test]
     fn try_from_file_time_to_offset_date_time() {
+        use time::macros::datetime;
+
         assert_eq!(
             OffsetDateTime::try_from(FileTime::NT_TIME_EPOCH).unwrap(),
             datetime!(1601-01-01 00:00 UTC)
@@ -640,25 +621,36 @@ mod tests {
     #[cfg(not(feature = "large-dates"))]
     #[test]
     fn try_from_file_time_to_offset_date_time_with_invalid_file_time() {
-        assert_eq!(
-            OffsetDateTime::try_from(FileTime::new(2_650_467_744_000_000_000)).unwrap_err(),
-            OffsetDateTimeRangeError
-        );
+        assert!(OffsetDateTime::try_from(FileTime::new(2_650_467_744_000_000_000)).is_err());
     }
 
     #[cfg(feature = "large-dates")]
     #[test]
-    fn try_from_file_time_to_offset_date_time_with_large_dates() {
+    fn from_file_time_to_offset_date_time() {
+        use time::macros::datetime;
+
         assert_eq!(
-            OffsetDateTime::try_from(FileTime::new(2_650_467_744_000_000_000)).unwrap(),
+            OffsetDateTime::from(FileTime::NT_TIME_EPOCH),
+            datetime!(1601-01-01 00:00 UTC)
+        );
+        assert_eq!(
+            OffsetDateTime::from(FileTime::UNIX_EPOCH),
+            OffsetDateTime::UNIX_EPOCH
+        );
+        assert_eq!(
+            OffsetDateTime::from(FileTime::new(2_650_467_743_999_999_999)),
+            datetime!(9999-12-31 23:59:59.999_999_900 UTC)
+        );
+        assert_eq!(
+            OffsetDateTime::from(FileTime::new(2_650_467_744_000_000_000)),
             datetime!(+10000-01-01 00:00 UTC)
         );
         assert_eq!(
-            OffsetDateTime::try_from(FileTime::new(i64::MAX.try_into().unwrap())).unwrap(),
+            OffsetDateTime::from(FileTime::new(i64::MAX.try_into().unwrap())),
             datetime!(+30828-09-14 02:48:05.477_580_700 UTC)
         );
         assert_eq!(
-            OffsetDateTime::try_from(FileTime::MAX).unwrap(),
+            OffsetDateTime::from(FileTime::MAX),
             datetime!(+60056-05-28 05:36:10.955_161_500 UTC)
         );
     }
@@ -722,6 +714,7 @@ mod tests {
     }
 
     #[cfg(feature = "zip")]
+    #[allow(clippy::cognitive_complexity)]
     #[test]
     fn try_from_file_time_to_zip_date_time() {
         use zip::DateTime;
@@ -917,16 +910,19 @@ mod tests {
 
     #[test]
     fn try_from_offset_date_time_to_file_time_before_nt_time_epoch() {
-        use time::Duration;
+        use time::{macros::datetime, Duration};
 
         assert_eq!(
-            FileTime::try_from(datetime!(1601-01-01 00:00 UTC) - Duration::NANOSECOND).unwrap_err(),
+            FileTime::try_from(datetime!(1601-01-01 00:00 UTC) - Duration::nanoseconds(100))
+                .unwrap_err(),
             FileTimeRangeError::new(FileTimeRangeErrorKind::Negative)
         );
     }
 
     #[test]
     fn try_from_offset_date_time_to_file_time() {
+        use time::macros::datetime;
+
         assert_eq!(
             FileTime::try_from(datetime!(1601-01-01 00:00 UTC)).unwrap(),
             FileTime::NT_TIME_EPOCH
@@ -944,6 +940,8 @@ mod tests {
     #[cfg(feature = "large-dates")]
     #[test]
     fn try_from_offset_date_time_to_file_time_with_large_dates() {
+        use time::macros::datetime;
+
         assert_eq!(
             FileTime::try_from(datetime!(+10000-01-01 00:00 UTC)).unwrap(),
             FileTime::new(2_650_467_744_000_000_000)
@@ -961,7 +959,7 @@ mod tests {
     #[cfg(feature = "large-dates")]
     #[test]
     fn try_from_offset_date_time_to_file_time_with_too_big_date_time() {
-        use time::Duration;
+        use time::{macros::datetime, Duration};
 
         assert_eq!(
             FileTime::try_from(
@@ -980,7 +978,7 @@ mod tests {
         assert_eq!(
             FileTime::try_from(
                 "1601-01-01 00:00:00 UTC".parse::<DateTime<Utc>>().unwrap()
-                    - TimeDelta::nanoseconds(1)
+                    - TimeDelta::nanoseconds(100)
             )
             .unwrap_err(),
             FileTimeRangeError::new(FileTimeRangeErrorKind::Negative)

--- a/src/file_time/ops.rs
+++ b/src/file_time/ops.rs
@@ -276,7 +276,11 @@ impl Sub<FileTime> for OffsetDateTime {
 
     #[inline]
     fn sub(self, rhs: FileTime) -> Self::Output {
-        self - Self::try_from(rhs).expect("RHS is out of range for `OffsetDateTime`")
+        #[cfg(not(feature = "large-dates"))]
+        let rhs = Self::try_from(rhs).expect("RHS is out of range for `OffsetDateTime`");
+        #[cfg(feature = "large-dates")]
+        let rhs = Self::from(rhs);
+        self - rhs
     }
 }
 
@@ -285,7 +289,11 @@ impl Sub<OffsetDateTime> for FileTime {
 
     #[inline]
     fn sub(self, rhs: OffsetDateTime) -> Self::Output {
-        OffsetDateTime::try_from(self).expect("LHS is out of range for `OffsetDateTime`") - rhs
+        #[cfg(not(feature = "large-dates"))]
+        let dt = OffsetDateTime::try_from(self).expect("LHS is out of range for `OffsetDateTime`");
+        #[cfg(feature = "large-dates")]
+        let dt = OffsetDateTime::from(self);
+        dt - rhs
     }
 }
 

--- a/src/serde_with/rfc_3339.rs
+++ b/src/serde_with/rfc_3339.rs
@@ -33,7 +33,7 @@
 
 pub mod option;
 
-use serde::{de::Error as _, ser::Error as _, Deserializer, Serializer};
+use serde::{de::Error as _, Deserializer, Serializer};
 use time::serde::rfc3339;
 
 use crate::FileTime;
@@ -45,7 +45,14 @@ use crate::FileTime;
 ///
 /// [RFC 3339 format]: https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
 pub fn serialize<S: Serializer>(ft: &FileTime, serializer: S) -> Result<S::Ok, S::Error> {
-    rfc3339::serialize(&(*ft).try_into().map_err(S::Error::custom)?, serializer)
+    #[cfg(not(feature = "large-dates"))]
+    use serde::ser::Error as _;
+
+    #[cfg(not(feature = "large-dates"))]
+    let dt = (*ft).try_into().map_err(S::Error::custom)?;
+    #[cfg(feature = "large-dates")]
+    let dt = (*ft).into();
+    rfc3339::serialize(&dt, serializer)
 }
 
 #[allow(clippy::missing_errors_doc)]
@@ -111,7 +118,7 @@ mod tests {
         assert_de_tokens_error::<Test>(
             &[
                 Token::NewtypeStruct { name: "Test" },
-                Token::BorrowedStr("1600-12-31T23:59:59.999999999Z"),
+                Token::BorrowedStr("1600-12-31T23:59:59.999999900Z"),
             ],
             "date and time is before `1601-01-01 00:00:00 UTC`",
         );


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Change to use `From<FileTime> for OffsetDateTime` when the `large-dates` feature is enabled, and `TryFrom<FileTime> for OffsetDateTime` when disabled. This is because this conversion always succeeds when the `large-dates` feature is enabled.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
