### PR TITLE
docs: Remove footnotes from documentation comments

### DIFF
--- a/src/file_time/convert.rs
+++ b/src/file_time/convert.rs
@@ -38,8 +38,9 @@ impl TryFrom<FileTime> for i64 {
 
     /// Converts a `FileTime` to the file time.
     ///
-    /// The file time may be represented as an [`i64`] value in [WinRT],[^clock]
-    /// [.NET],[^fromfiletime][^tofiletime] etc.
+    /// The file time is sometimes represented as an [`i64`] value, such as the
+    /// [`winrt::clock`] struct in [WinRT], or the [`DateTime.FromFileTime`]
+    /// method and the [`DateTime.ToFileTime`] method in [.NET].
     ///
     /// # Errors
     ///
@@ -62,13 +63,10 @@ impl TryFrom<FileTime> for i64 {
     /// assert!(i64::try_from(FileTime::MAX).is_err());
     /// ```
     ///
-    /// [^clock]: <https://learn.microsoft.com/en-us/uwp/cpp-ref-for-winrt/clock>
-    ///
-    /// [^fromfiletime]: <https://learn.microsoft.com/en-us/dotnet/api/system.datetime.fromfiletime>
-    ///
-    /// [^tofiletime]: <https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tofiletime>
-    ///
+    /// [`winrt::clock`]: https://learn.microsoft.com/en-us/uwp/cpp-ref-for-winrt/clock
     /// [WinRT]: https://learn.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/
+    /// [`DateTime.FromFileTime`]: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.fromfiletime
+    /// [`DateTime.ToFileTime`]: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tofiletime
     /// [.NET]: https://dotnet.microsoft.com/
     #[inline]
     fn try_from(ft: FileTime) -> Result<Self, Self::Error> {
@@ -238,8 +236,9 @@ impl TryFrom<i64> for FileTime {
 
     /// Converts the file time to a `FileTime`.
     ///
-    /// The file time may be represented as an [`i64`] value in [WinRT],[^clock]
-    /// [.NET],[^fromfiletime][^tofiletime] etc.
+    /// The file time is sometimes represented as an [`i64`] value, such as the
+    /// [`winrt::clock`] struct in [WinRT], or the [`DateTime.FromFileTime`]
+    /// method and the [`DateTime.ToFileTime`] method in [.NET].
     ///
     /// # Errors
     ///
@@ -262,13 +261,10 @@ impl TryFrom<i64> for FileTime {
     /// assert!(FileTime::try_from(i64::MIN).is_err());
     /// ```
     ///
-    /// [^clock]: <https://learn.microsoft.com/en-us/uwp/cpp-ref-for-winrt/clock>
-    ///
-    /// [^fromfiletime]: <https://learn.microsoft.com/en-us/dotnet/api/system.datetime.fromfiletime>
-    ///
-    /// [^tofiletime]: <https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tofiletime>
-    ///
+    /// [`winrt::clock`]: https://learn.microsoft.com/en-us/uwp/cpp-ref-for-winrt/clock
     /// [WinRT]: https://learn.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/
+    /// [`DateTime.FromFileTime`]: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.fromfiletime
+    /// [`DateTime.ToFileTime`]: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tofiletime
     /// [.NET]: https://dotnet.microsoft.com/
     #[inline]
     fn try_from(ft: i64) -> Result<Self, Self::Error> {

--- a/src/file_time/dos_date_time.rs
+++ b/src/file_time/dos_date_time.rs
@@ -38,8 +38,7 @@ impl FileTime {
     ///
     /// # Panics
     ///
-    /// Panics if `offset` is not in the range "UTC-16:00" to
-    /// "UTC+15:45".[^offsetfromutc-field]
+    /// Panics if `offset` is out of range for the [OffsetFromUtc field].
     ///
     /// # Examples
     ///
@@ -109,14 +108,13 @@ impl FileTime {
     /// );
     /// ```
     ///
-    /// [^offsetfromutc-field]: <https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#74101-offsetfromutc-field>
-    ///
     /// [MS-DOS date and time]: https://learn.microsoft.com/en-us/windows/win32/sysinfo/ms-dos-date-and-time
     /// [FAT]: https://en.wikipedia.org/wiki/File_Allocation_Table
     /// [exFAT]: https://en.wikipedia.org/wiki/ExFAT
     /// [ZIP]: https://en.wikipedia.org/wiki/ZIP_(file_format)
     /// [finer resolution]: https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#749-10msincrement-fields
     /// [UTC offset]: https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#7410-utcoffset-fields
+    /// [OffsetFromUtc field]: https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#74101-offsetfromutc-field
     pub fn to_dos_date_time(
         self,
         offset: Option<UtcOffset>,
@@ -184,8 +182,7 @@ impl FileTime {
     /// Panics if any of the following are true:
     ///
     /// - `resolution` is greater than 199.
-    /// - `offset` is not in the range "UTC-16:00" to
-    ///   "UTC+15:45".[^offsetfromutc-field]
+    /// - `offset` is out of range for the [OffsetFromUtc field].
     ///
     /// # Examples
     ///
@@ -247,13 +244,12 @@ impl FileTime {
     /// let _: FileTime = FileTime::from_dos_date_time(0x0021, u16::MIN, Some(200), None).unwrap();
     /// ```
     ///
-    /// [^offsetfromutc-field]: <https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#74101-offsetfromutc-field>
-    ///
     /// [MS-DOS date and time]: https://learn.microsoft.com/en-us/windows/win32/sysinfo/ms-dos-date-and-time
     /// [FAT]: https://en.wikipedia.org/wiki/File_Allocation_Table
     /// [exFAT]: https://en.wikipedia.org/wiki/ExFAT
     /// [ZIP]: https://en.wikipedia.org/wiki/ZIP_(file_format)
     /// [finer resolution]: https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#749-10msincrement-fields
+    /// [OffsetFromUtc field]: https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#74101-offsetfromutc-field
     /// [UTC offset]: https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#7410-utcoffset-fields
     pub fn from_dos_date_time(
         date: u16,


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Replace footnotes with links to suppress `rustdoc::unportable-markdown` lint warnings.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
