### PR TITLE
test: Remove type annotation from `let _`

### DIFF
--- a/src/file_time/dos_date_time.rs
+++ b/src/file_time/dos_date_time.rs
@@ -241,7 +241,7 @@ impl FileTime {
     /// ```should_panic
     /// # use nt_time::FileTime;
     /// #
-    /// let _: FileTime = FileTime::from_dos_date_time(0x0021, u16::MIN, Some(200), None).unwrap();
+    /// let _ = FileTime::from_dos_date_time(0x0021, u16::MIN, Some(200), None).unwrap();
     /// ```
     ///
     /// [MS-DOS date and time]: https://learn.microsoft.com/en-us/windows/win32/sysinfo/ms-dos-date-and-time
@@ -558,7 +558,7 @@ mod tests {
     #[allow(clippy::should_panic_without_expect)]
     fn to_dos_date_time_with_invalid_positive_offset() {
         // From `1980-01-01 00:00:00 UTC` to `1980-01-01 16:00:00 +16:00`.
-        let _: (u16, u16, u8, Option<UtcOffset>) = FileTime::new(119_600_064_000_000_000)
+        let _ = FileTime::new(119_600_064_000_000_000)
             .to_dos_date_time(Some(offset!(+16:00)))
             .unwrap();
     }
@@ -568,7 +568,7 @@ mod tests {
     #[allow(clippy::should_panic_without_expect)]
     fn to_dos_date_time_with_invalid_negative_offset() {
         // From `2107-12-31 23:59:58 UTC` to `2107-12-31 07:44:58 -16:15`.
-        let _: (u16, u16, u8, Option<UtcOffset>) = FileTime::new(159_992_927_980_000_000)
+        let _ = FileTime::new(159_992_927_980_000_000)
             .to_dos_date_time(Some(offset!(-16:15)))
             .unwrap();
     }
@@ -734,7 +734,7 @@ mod tests {
     #[should_panic]
     #[allow(clippy::should_panic_without_expect)]
     fn from_dos_date_time_with_invalid_resolution() {
-        let _: FileTime = FileTime::from_dos_date_time(0x0021, u16::MIN, Some(200), None).unwrap();
+        let _ = FileTime::from_dos_date_time(0x0021, u16::MIN, Some(200), None).unwrap();
     }
 
     #[test]
@@ -742,8 +742,7 @@ mod tests {
     #[allow(clippy::should_panic_without_expect)]
     fn from_dos_date_time_with_invalid_positive_offset() {
         // From `2107-12-31 23:59:58 +16:00` to `2107-12-31 07:59:58 UTC`.
-        let _: FileTime =
-            FileTime::from_dos_date_time(0xff9f, 0xbf7d, None, Some(offset!(+16:00))).unwrap();
+        let _ = FileTime::from_dos_date_time(0xff9f, 0xbf7d, None, Some(offset!(+16:00))).unwrap();
     }
 
     #[test]
@@ -751,7 +750,7 @@ mod tests {
     #[allow(clippy::should_panic_without_expect)]
     fn from_dos_date_time_with_invalid_negative_offset() {
         // From `1980-01-01 00:00:00 -16:15` to `1980-01-01 16:15:00 UTC`.
-        let _: FileTime =
+        let _ =
             FileTime::from_dos_date_time(0x0021, u16::MIN, None, Some(offset!(-16:15))).unwrap();
     }
 }

--- a/src/file_time/ops.rs
+++ b/src/file_time/ops.rs
@@ -574,7 +574,7 @@ mod tests {
     fn add_std_duration_with_overflow() {
         use core::time::Duration;
 
-        let _: FileTime = FileTime::MAX + Duration::from_nanos(100);
+        let _ = FileTime::MAX + Duration::from_nanos(100);
     }
 
     #[test]
@@ -608,7 +608,7 @@ mod tests {
     fn add_positive_time_duration_with_overflow() {
         use time::Duration;
 
-        let _: FileTime = FileTime::MAX + Duration::nanoseconds(100);
+        let _ = FileTime::MAX + Duration::nanoseconds(100);
     }
 
     #[test]
@@ -642,7 +642,7 @@ mod tests {
     fn add_negative_time_duration_with_overflow() {
         use time::Duration;
 
-        let _: FileTime = FileTime::NT_TIME_EPOCH + Duration::nanoseconds(-100);
+        let _ = FileTime::NT_TIME_EPOCH + Duration::nanoseconds(-100);
     }
 
     #[cfg(feature = "chrono")]
@@ -678,7 +678,7 @@ mod tests {
     fn add_positive_chrono_time_delta_with_overflow() {
         use chrono::TimeDelta;
 
-        let _: FileTime = FileTime::MAX + TimeDelta::nanoseconds(100);
+        let _ = FileTime::MAX + TimeDelta::nanoseconds(100);
     }
 
     #[cfg(feature = "chrono")]
@@ -714,7 +714,7 @@ mod tests {
     fn add_negative_chrono_time_delta_with_overflow() {
         use chrono::TimeDelta;
 
-        let _: FileTime = FileTime::NT_TIME_EPOCH + TimeDelta::nanoseconds(-100);
+        let _ = FileTime::NT_TIME_EPOCH + TimeDelta::nanoseconds(-100);
     }
 
     #[test]
@@ -996,7 +996,7 @@ mod tests {
     fn sub_file_time_with_overflow() {
         use core::time::Duration;
 
-        let _: Duration = (FileTime::MAX - Duration::from_nanos(100)) - FileTime::MAX;
+        let _ = (FileTime::MAX - Duration::from_nanos(100)) - FileTime::MAX;
     }
 
     #[test]
@@ -1030,7 +1030,7 @@ mod tests {
     fn sub_std_duration_with_overflow() {
         use core::time::Duration;
 
-        let _: FileTime = FileTime::NT_TIME_EPOCH - Duration::from_nanos(100);
+        let _ = FileTime::NT_TIME_EPOCH - Duration::from_nanos(100);
     }
 
     #[test]
@@ -1064,7 +1064,7 @@ mod tests {
     fn sub_positive_time_duration_with_overflow() {
         use time::Duration;
 
-        let _: FileTime = FileTime::NT_TIME_EPOCH - Duration::nanoseconds(100);
+        let _ = FileTime::NT_TIME_EPOCH - Duration::nanoseconds(100);
     }
 
     #[test]
@@ -1098,7 +1098,7 @@ mod tests {
     fn sub_negative_time_duration_with_overflow() {
         use time::Duration;
 
-        let _: FileTime = FileTime::MAX - Duration::nanoseconds(-100);
+        let _ = FileTime::MAX - Duration::nanoseconds(-100);
     }
 
     #[cfg(feature = "chrono")]
@@ -1134,7 +1134,7 @@ mod tests {
     fn sub_positive_chrono_time_delta_with_overflow() {
         use chrono::TimeDelta;
 
-        let _: FileTime = FileTime::NT_TIME_EPOCH - TimeDelta::nanoseconds(100);
+        let _ = FileTime::NT_TIME_EPOCH - TimeDelta::nanoseconds(100);
     }
 
     #[cfg(feature = "chrono")]
@@ -1170,7 +1170,7 @@ mod tests {
     fn sub_negative_chrono_time_delta_with_overflow() {
         use chrono::TimeDelta;
 
-        let _: FileTime = FileTime::MAX - TimeDelta::nanoseconds(-100);
+        let _ = FileTime::MAX - TimeDelta::nanoseconds(-100);
     }
 
     #[cfg(feature = "std")]
@@ -1201,7 +1201,7 @@ mod tests {
     fn sub_file_time_from_system_time_with_overflow() {
         use std::time::{Duration, SystemTime};
 
-        let _: Duration = FileTime::new(9_223_372_036_854_775_806)
+        let _ = FileTime::new(9_223_372_036_854_775_806)
             - (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700));
     }
 
@@ -1242,7 +1242,7 @@ mod tests {
     fn sub_system_time_from_file_time_with_overflow() {
         use std::time::{Duration, SystemTime};
 
-        let _: Duration = (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_600))
+        let _ = (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_600))
             - FileTime::new(9_223_372_036_854_775_807);
     }
 

--- a/src/file_time/unix_time.rs
+++ b/src/file_time/unix_time.rs
@@ -195,7 +195,7 @@ impl FileTime {
     /// ```should_panic
     /// # use nt_time::FileTime;
     /// #
-    /// let _: FileTime = FileTime::from_unix_time(0, 1_000_000_000).unwrap();
+    /// let _ = FileTime::from_unix_time(0, 1_000_000_000).unwrap();
     /// ```
     ///
     /// [Unix time]: https://en.wikipedia.org/wiki/Unix_time
@@ -821,7 +821,7 @@ mod tests {
     #[should_panic]
     #[allow(clippy::should_panic_without_expect)]
     fn from_unix_time_with_too_big_subsec_nanos() {
-        let _: FileTime = FileTime::from_unix_time(i64::default(), NANOS_PER_SEC).unwrap();
+        let _ = FileTime::from_unix_time(i64::default(), NANOS_PER_SEC).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Because `clippy::let_underscore_untyped` was downgraded to `clippy::restriction`.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
