### PR TITLE
refactor: Change how `FileTime::SIGNED_MAX` is defined

### DIFF
--- a/src/file_time/consts.rs
+++ b/src/file_time/consts.rs
@@ -54,21 +54,24 @@ impl FileTime {
     /// value instead of [`FileTime::MAX`].
     ///
     /// Note that the actual largest value of the [`SYSTEMTIME`] structure of
-    /// the Win32 API is "+30827-12-31 23:59:59.999000000", which is different
-    /// from this constant. The `FileTimeToSystemTime` function accepts the
-    /// value of this constant, but it is an invalid date and time for the
-    /// `SYSTEMTIME` structure.
+    /// the Win32 API is "+30827-12-31 23:59:59.999000000" (which is either in
+    /// UTC or local time, depending on the function that is being called),
+    /// which is different from this constant. The `FileTimeToSystemTime`
+    /// function accepts the value of this constant, but it is an invalid date
+    /// and time for the `SYSTEMTIME` structure.
     ///
     /// # Examples
     ///
     /// ```
+    /// # #[cfg(feature = "large-dates")]
+    /// # {
     /// # use nt_time::{time::macros::datetime, FileTime};
     /// #
-    /// # #[cfg(feature = "large-dates")]
     /// assert_eq!(
     ///     FileTime::SIGNED_MAX,
     ///     datetime!(+30828-09-14 02:48:05.477_580_700 UTC)
     /// );
+    /// # }
     /// ```
     ///
     /// [`FileTimeToSystemTime`]: https://learn.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-filetimetosystemtime
@@ -80,7 +83,7 @@ impl FileTime {
     /// [`DateTime.ToFileTime`]: https://learn.microsoft.com/en-us/dotnet/api/system.datetime.tofiletime
     /// [.NET]: https://dotnet.microsoft.com/
     /// [`SYSTEMTIME`]: https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-systemtime
-    pub const SIGNED_MAX: Self = Self::new(u64::MAX >> 1);
+    pub const SIGNED_MAX: Self = Self::new(i64::MAX as u64);
 
     /// The largest value that can be represented by the file time.
     ///
@@ -98,13 +101,15 @@ impl FileTime {
     /// # Examples
     ///
     /// ```
+    /// # #[cfg(feature = "large-dates")]
+    /// # {
     /// # use nt_time::{time::macros::datetime, FileTime};
     /// #
-    /// # #[cfg(feature = "large-dates")]
     /// assert_eq!(
     ///     FileTime::MAX,
     ///     datetime!(+60056-05-28 05:36:10.955_161_500 UTC)
     /// );
+    /// # }
     /// ```
     ///
     /// [`FILETIME`]: https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime

--- a/src/file_time/convert.rs
+++ b/src/file_time/convert.rs
@@ -143,35 +143,37 @@ impl TryFrom<FileTime> for OffsetDateTime {
     /// time represents after "9999-12-31 23:59:59.999999900 UTC":
     ///
     /// ```
+    /// # #[cfg(not(feature = "large-dates"))]
+    /// # {
     /// # use nt_time::{time::OffsetDateTime, FileTime};
     /// #
-    /// # #[cfg(not(feature = "large-dates"))]
     /// assert!(OffsetDateTime::try_from(FileTime::new(2_650_467_744_000_000_000)).is_err());
+    /// # }
     /// ```
     ///
     /// With the `large-dates` feature enabled, this always succeeds:
     ///
     /// ```
+    /// # #[cfg(feature = "large-dates")]
+    /// # {
     /// # use nt_time::{
     /// #     time::{macros::datetime, OffsetDateTime},
     /// #     FileTime,
     /// # };
     /// #
-    /// # #[cfg(feature = "large-dates")]
     /// assert_eq!(
     ///     OffsetDateTime::try_from(FileTime::new(2_650_467_744_000_000_000)).unwrap(),
     ///     datetime!(+10000-01-01 00:00 UTC)
     /// );
-    /// # #[cfg(feature = "large-dates")]
     /// assert_eq!(
     ///     OffsetDateTime::try_from(FileTime::SIGNED_MAX).unwrap(),
     ///     datetime!(+30828-09-14 02:48:05.477_580_700 UTC)
     /// );
-    /// # #[cfg(feature = "large-dates")]
     /// assert_eq!(
     ///     OffsetDateTime::try_from(FileTime::MAX).unwrap(),
     ///     datetime!(+60056-05-28 05:36:10.955_161_500 UTC)
     /// );
+    /// # }
     /// ```
     #[inline]
     fn try_from(ft: FileTime) -> Result<Self, Self::Error> {
@@ -362,16 +364,18 @@ impl TryFrom<OffsetDateTime> for FileTime {
     /// UTC":
     ///
     /// ```
+    /// # #[cfg(feature = "large-dates")]
+    /// # {
     /// # use nt_time::{
     /// #     time::{macros::datetime, Duration},
     /// #     FileTime,
     /// # };
     /// #
-    /// # #[cfg(feature = "large-dates")]
     /// assert!(FileTime::try_from(
     ///     datetime!(+60056-05-28 05:36:10.955_161_500 UTC) + Duration::nanoseconds(100)
     /// )
     /// .is_err());
+    /// # }
     /// ```
     #[inline]
     fn try_from(dt: OffsetDateTime) -> Result<Self, Self::Error> {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
