### PR TITLE
Omit LICENSES/CC-BY-4.0.txt from the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ repository = "https://github.com/sorairolake/nt-time"
 license = "Apache-2.0 OR MIT"
 keywords = ["date", "time", "windows"]
 categories = ["date-and-time", "no-std"]
-include = ["/LICENSES", "/README.md", "/src"]
+# CC-BY-4.0.txt is for CODE_OF_CONDUCT.md, which is not shipped in the crate.
+include = ["/LICENSES/", "!/LICENSES/CC-BY-4.0.txt", "/README.md", "/src"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
It is for `CODE_OF_CONDUCT.md`, which is not shipped in the crate. There is therefore no need to include this particular license file in the crate.

## Description

<!-- Describe your changes in detail. -->

Exclude `LICENSES/CC-BY-4.0.txt` from the crate, while still including anything else in `LICENSES/`; add an explanatory comment.
<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [x] I have read the [Contribution Guide].
- [x] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
