### PR TITLE
feat: Add methods to convert `FileTime` and `Duration`

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -38,7 +38,7 @@ jobs:
             os: windows-2025
             target: x86_64-pc-windows-msvc
           - toolchain-alias: msrv
-            toolchain: 1.88.0
+            toolchain: 1.93.0
           - toolchain-alias: stable
             toolchain: stable
     steps:
@@ -91,7 +91,7 @@ jobs:
             os: windows-2025
             target: x86_64-pc-windows-msvc
           - toolchain-alias: msrv
-            toolchain: 1.88.0
+            toolchain: 1.93.0
           - toolchain-alias: stable
             toolchain: stable
     steps:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,17 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/v0.13.2\...HEAD[Unreleased]
+
+=== Added
+
+* Add `FileTime::to_duration` ({pull-request-url}/435[#435])
+* Add `FileTime::from_duration` ({pull-request-url}/435[#435])
+
+=== Changed
+
+* Bump MSRV to 1.93.0 ({pull-request-url}/435[#435])
+
 == {compare-url}/v0.13.1\...v0.13.2[0.13.2] - 2026-02-12
 
 === Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 name = "nt-time"
 version = "0.13.2"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.93.0"
 description = "A Windows file time library"
 documentation = "https://docs.rs/nt-time"
 repository = "https://github.com/sorairolake/nt-time"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See the [documentation][docs-url] for more details.
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version (MSRV) of this library is v1.88.0.
+The minimum supported Rust version (MSRV) of this library is v1.93.0.
 
 ## Source code
 

--- a/benches/cmp.rs
+++ b/benches/cmp.rs
@@ -88,10 +88,7 @@ fn order_system_time_and_file_time(b: &mut Bencher) {
 #[cfg(feature = "std")]
 #[bench]
 fn order_file_time_and_system_time(b: &mut Bencher) {
-    b.iter(|| {
-        FileTime::UNIX_EPOCH
-            > (SystemTime::UNIX_EPOCH - (FileTime::UNIX_EPOCH - FileTime::NT_TIME_EPOCH))
-    });
+    b.iter(|| FileTime::UNIX_EPOCH > (SystemTime::UNIX_EPOCH - FileTime::UNIX_EPOCH.to_duration()));
 }
 
 #[bench]

--- a/benches/duration.rs
+++ b/benches/duration.rs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Shun Sakai
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#![feature(test)]
+
+extern crate test;
+
+use core::time::Duration;
+
+use nt_time::FileTime;
+use test::Bencher;
+
+#[bench]
+fn to_duration(b: &mut Bencher) {
+    b.iter(|| FileTime::NT_TIME_EPOCH.to_duration());
+}
+
+#[bench]
+fn from_duration(b: &mut Bencher) {
+    b.iter(|| FileTime::from_duration(Duration::ZERO).unwrap());
+}

--- a/src/file_time.rs
+++ b/src/file_time.rs
@@ -9,6 +9,7 @@
 mod cmp;
 mod consts;
 mod convert;
+mod duration;
 mod fmt;
 mod from_str;
 mod ops;

--- a/src/file_time/cmp.rs
+++ b/src/file_time/cmp.rs
@@ -337,8 +337,7 @@ mod tests {
             Some(Ordering::Equal)
         );
         assert!(
-            FileTime::UNIX_EPOCH
-                > (SystemTime::UNIX_EPOCH - (FileTime::UNIX_EPOCH - FileTime::NT_TIME_EPOCH))
+            FileTime::UNIX_EPOCH > (SystemTime::UNIX_EPOCH - FileTime::UNIX_EPOCH.to_duration())
         );
     }
 

--- a/src/file_time/convert.rs
+++ b/src/file_time/convert.rs
@@ -6,7 +6,7 @@
 
 use core::num::TryFromIntError;
 #[cfg(feature = "std")]
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 
 #[cfg(feature = "chrono")]
 use chrono::Utc;
@@ -19,8 +19,6 @@ use dos_date_time::{
 use jiff::Timestamp;
 use time::{UtcDateTime, error::ComponentRange};
 
-#[cfg(feature = "std")]
-use super::FILE_TIMES_PER_SEC;
 use super::FileTime;
 use crate::error::{FileTimeRangeError, FileTimeRangeErrorKind};
 
@@ -98,7 +96,7 @@ impl From<FileTime> for SystemTime {
     /// #
     /// assert_eq!(
     ///     SystemTime::from(FileTime::NT_TIME_EPOCH),
-    ///     SystemTime::UNIX_EPOCH - Duration::from_secs(11_644_473_600)
+    ///     SystemTime::UNIX_EPOCH - Duration::from_hours(3_234_576)
     /// );
     /// assert_eq!(
     ///     SystemTime::from(FileTime::UNIX_EPOCH),
@@ -106,12 +104,8 @@ impl From<FileTime> for SystemTime {
     /// );
     /// ```
     fn from(ft: FileTime) -> Self {
-        let duration = Duration::new(
-            ft.to_raw() / FILE_TIMES_PER_SEC,
-            u32::try_from((ft.to_raw() % FILE_TIMES_PER_SEC) * 100)
-                .expect("the number of nanoseconds should be in the range of `u32`"),
-        );
-        (Self::UNIX_EPOCH - (FileTime::UNIX_EPOCH - FileTime::NT_TIME_EPOCH)) + duration
+        let duration = ft.to_duration();
+        (Self::UNIX_EPOCH - FileTime::UNIX_EPOCH.to_duration()) + duration
     }
 }
 
@@ -366,7 +360,7 @@ impl TryFrom<SystemTime> for FileTime {
     /// # use nt_time::FileTime;
     /// #
     /// assert_eq!(
-    ///     FileTime::try_from(SystemTime::UNIX_EPOCH - Duration::from_secs(11_644_473_600)),
+    ///     FileTime::try_from(SystemTime::UNIX_EPOCH - Duration::from_hours(3_234_576)),
     ///     Ok(FileTime::NT_TIME_EPOCH)
     /// );
     /// assert_eq!(
@@ -390,11 +384,9 @@ impl TryFrom<SystemTime> for FileTime {
     /// ```
     fn try_from(st: SystemTime) -> Result<Self, Self::Error> {
         let elapsed = st
-            .duration_since(SystemTime::UNIX_EPOCH - (Self::UNIX_EPOCH - Self::NT_TIME_EPOCH))
-            .map(|d| d.as_nanos())
+            .duration_since(SystemTime::UNIX_EPOCH - Self::UNIX_EPOCH.to_duration())
             .map_err(|_| FileTimeRangeErrorKind::Negative)?;
-        let ft = u64::try_from(elapsed / 100).map_err(|_| FileTimeRangeErrorKind::Overflow)?;
-        Ok(Self::new(ft))
+        Self::from_duration(elapsed)
     }
 }
 
@@ -571,6 +563,9 @@ impl From<dos_date_time::DateTime> for FileTime {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "std")]
+    use std::time::Duration;
+
     #[cfg(feature = "chrono")]
     use chrono::TimeDelta;
     #[cfg(feature = "dos-date-time")]
@@ -633,7 +628,7 @@ mod tests {
     fn from_file_time_to_system_time() {
         assert_eq!(
             SystemTime::from(FileTime::NT_TIME_EPOCH),
-            SystemTime::UNIX_EPOCH - (FileTime::UNIX_EPOCH - FileTime::NT_TIME_EPOCH)
+            SystemTime::UNIX_EPOCH - FileTime::UNIX_EPOCH.to_duration()
         );
         assert_eq!(
             SystemTime::from(FileTime::UNIX_EPOCH),
@@ -645,7 +640,7 @@ mod tests {
         );
         assert_eq!(
             SystemTime::from(FileTime::new(2_650_467_744_000_000_000)),
-            SystemTime::UNIX_EPOCH + Duration::from_secs(253_402_300_800)
+            SystemTime::UNIX_EPOCH + Duration::from_hours(70_389_528)
         );
         // Largest `SystemTime` on Windows.
         assert_eq!(
@@ -908,10 +903,8 @@ mod tests {
     #[test]
     fn try_from_system_time_to_file_time() {
         assert_eq!(
-            FileTime::try_from(
-                SystemTime::UNIX_EPOCH - (FileTime::UNIX_EPOCH - FileTime::NT_TIME_EPOCH)
-            )
-            .unwrap(),
+            FileTime::try_from(SystemTime::UNIX_EPOCH - FileTime::UNIX_EPOCH.to_duration())
+                .unwrap(),
             FileTime::NT_TIME_EPOCH
         );
         assert_eq!(
@@ -926,8 +919,7 @@ mod tests {
             FileTime::new(2_650_467_743_999_999_999)
         );
         assert_eq!(
-            FileTime::try_from(SystemTime::UNIX_EPOCH + Duration::from_secs(253_402_300_800))
-                .unwrap(),
+            FileTime::try_from(SystemTime::UNIX_EPOCH + Duration::from_hours(70_389_528)).unwrap(),
             FileTime::new(2_650_467_744_000_000_000)
         );
         // Largest `SystemTime` on Windows.

--- a/src/file_time/duration.rs
+++ b/src/file_time/duration.rs
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: 2026 Shun Sakai
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Implementations of conversions between [`FileTime`] and [`Duration`].
+
+use core::time::Duration;
+
+use super::FileTime;
+use crate::error::{FileTimeRangeError, FileTimeRangeErrorKind};
+
+impl FileTime {
+    /// Returns this `FileTime` as a [`Duration`] since
+    /// [`FileTime::NT_TIME_EPOCH`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use core::time::Duration;
+    /// #
+    /// # use nt_time::FileTime;
+    /// #
+    /// assert_eq!(FileTime::NT_TIME_EPOCH.to_duration(), Duration::ZERO);
+    /// assert_eq!(
+    ///     FileTime::UNIX_EPOCH.to_duration(),
+    ///     Duration::from_hours(3_234_576)
+    /// );
+    /// assert_eq!(
+    ///     FileTime::SIGNED_MAX.to_duration(),
+    ///     Duration::new(922_337_203_685, 477_580_700)
+    /// );
+    /// assert_eq!(
+    ///     FileTime::MAX.to_duration(),
+    ///     Duration::new(1_844_674_407_370, 955_161_500)
+    /// );
+    /// ```
+    #[must_use]
+    pub fn to_duration(self) -> Duration {
+        Duration::from_nanos_u128(u128::from(self.to_raw()) * 100)
+    }
+
+    /// Creates a `FileTime` from a [`Duration`] since
+    /// [`FileTime::NT_TIME_EPOCH`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if `duration` is greater than [`FileTime::MAX`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use core::time::Duration;
+    /// #
+    /// # use nt_time::FileTime;
+    /// #
+    /// assert_eq!(
+    ///     FileTime::from_duration(Duration::ZERO),
+    ///     Ok(FileTime::NT_TIME_EPOCH)
+    /// );
+    /// assert_eq!(
+    ///     FileTime::from_duration(Duration::from_hours(3_234_576)),
+    ///     Ok(FileTime::UNIX_EPOCH)
+    /// );
+    /// assert_eq!(
+    ///     FileTime::from_duration(Duration::new(922_337_203_685, 477_580_700)),
+    ///     Ok(FileTime::SIGNED_MAX)
+    /// );
+    /// assert_eq!(
+    ///     FileTime::from_duration(Duration::new(1_844_674_407_370, 955_161_500)),
+    ///     Ok(FileTime::MAX)
+    /// );
+    ///
+    /// // After `+60056-05-28 05:36:10.955161500 UTC`.
+    /// assert!(FileTime::from_duration(Duration::new(1_844_674_407_370, 955_161_600)).is_err());
+    /// ```
+    pub fn from_duration(duration: Duration) -> Result<Self, FileTimeRangeError> {
+        u64::try_from(duration.as_nanos() / 100)
+            .map_err(|_| FileTimeRangeErrorKind::Overflow.into())
+            .map(Self::new)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::FILE_TIMES_PER_SEC, *};
+
+    #[test]
+    fn to_duration() {
+        assert_eq!(FileTime::NT_TIME_EPOCH.to_duration(), Duration::ZERO);
+        assert_eq!(FileTime::new(1).to_duration(), Duration::from_nanos(100));
+        assert_eq!(
+            FileTime::new(FILE_TIMES_PER_SEC - 1).to_duration(),
+            Duration::from_nanos(999_999_900)
+        );
+        assert_eq!(
+            FileTime::new(FILE_TIMES_PER_SEC).to_duration(),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            (FileTime::UNIX_EPOCH - Duration::from_nanos(100)).to_duration(),
+            Duration::new(11_644_473_599, 999_999_900)
+        );
+        assert_eq!(
+            FileTime::UNIX_EPOCH.to_duration(),
+            Duration::from_hours(3_234_576)
+        );
+        assert_eq!(
+            (FileTime::UNIX_EPOCH + Duration::from_nanos(100)).to_duration(),
+            Duration::new(11_644_473_600, 100)
+        );
+        assert_eq!(
+            FileTime::SIGNED_MAX.to_duration(),
+            Duration::new(922_337_203_685, 477_580_700)
+        );
+        assert_eq!(
+            (FileTime::MAX - Duration::from_nanos(100)).to_duration(),
+            Duration::new(1_844_674_407_370, 955_161_400)
+        );
+        assert_eq!(
+            FileTime::MAX.to_duration(),
+            Duration::new(1_844_674_407_370, 955_161_500)
+        );
+    }
+
+    #[test]
+    fn from_duration() {
+        assert_eq!(
+            FileTime::from_duration(Duration::ZERO).unwrap(),
+            FileTime::NT_TIME_EPOCH
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::from_nanos(1)).unwrap(),
+            FileTime::NT_TIME_EPOCH
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::from_nanos(99)).unwrap(),
+            FileTime::NT_TIME_EPOCH
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::from_nanos(100)).unwrap(),
+            FileTime::new(1)
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::from_nanos(999_999_900)).unwrap(),
+            FileTime::new(FILE_TIMES_PER_SEC - 1)
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::from_nanos(999_999_901)).unwrap(),
+            FileTime::new(FILE_TIMES_PER_SEC - 1)
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::from_nanos(999_999_999)).unwrap(),
+            FileTime::new(FILE_TIMES_PER_SEC - 1)
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::from_secs(1)).unwrap(),
+            FileTime::new(FILE_TIMES_PER_SEC)
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::new(11_644_473_599, 999_999_900)).unwrap(),
+            FileTime::UNIX_EPOCH - Duration::from_nanos(100)
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::new(11_644_473_599, 999_999_901)).unwrap(),
+            FileTime::UNIX_EPOCH - Duration::from_nanos(100)
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::new(11_644_473_599, 999_999_999)).unwrap(),
+            FileTime::UNIX_EPOCH - Duration::from_nanos(100)
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::from_hours(3_234_576)).unwrap(),
+            FileTime::UNIX_EPOCH
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::new(11_644_473_600, 1)).unwrap(),
+            FileTime::UNIX_EPOCH
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::new(11_644_473_600, 99)).unwrap(),
+            FileTime::UNIX_EPOCH
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::new(11_644_473_600, 100)).unwrap(),
+            FileTime::UNIX_EPOCH + Duration::from_nanos(100)
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::new(922_337_203_685, 477_580_700)).unwrap(),
+            FileTime::SIGNED_MAX
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::new(1_844_674_407_370, 955_161_500)).unwrap(),
+            FileTime::MAX
+        );
+    }
+
+    #[test]
+    fn from_duration_with_too_big_date_time() {
+        assert_eq!(
+            FileTime::from_duration(Duration::new(1_844_674_407_370, 955_161_600)).unwrap_err(),
+            FileTimeRangeErrorKind::Overflow.into()
+        );
+        assert_eq!(
+            FileTime::from_duration(Duration::MAX).unwrap_err(),
+            FileTimeRangeErrorKind::Overflow.into()
+        );
+    }
+}

--- a/src/file_time/ops.rs
+++ b/src/file_time/ops.rs
@@ -17,7 +17,7 @@ use chrono::{DateTime, TimeDelta, Utc};
 use jiff::{Span, Timestamp};
 use time::UtcDateTime;
 
-use super::{FILE_TIMES_PER_SEC, FileTime};
+use super::FileTime;
 
 impl FileTime {
     /// Computes `self + rhs`, returning [`None`] if overflow occurred.
@@ -234,11 +234,7 @@ impl Sub for FileTime {
 
     fn sub(self, rhs: Self) -> Self::Output {
         let duration = self.to_raw() - rhs.to_raw();
-        Self::Output::new(
-            duration / FILE_TIMES_PER_SEC,
-            u32::try_from((duration % FILE_TIMES_PER_SEC) * 100)
-                .expect("the number of nanoseconds should be in the range of `u32`"),
-        )
+        Self::Output::from_nanos_u128(u128::from(duration) * 100)
     }
 }
 
@@ -436,11 +432,11 @@ mod tests {
 
     #[cfg(feature = "std")]
     #[proptest]
-    fn checked_add_roundtrip(dur: Duration) {
-        if dur <= Duration::new(1_844_674_407_370, 955_161_500) {
-            prop_assert!(FileTime::NT_TIME_EPOCH.checked_add(dur).is_some());
+    fn checked_add_roundtrip(duration: Duration) {
+        if duration <= Duration::new(1_844_674_407_370, 955_161_500) {
+            prop_assert!(FileTime::NT_TIME_EPOCH.checked_add(duration).is_some());
         } else {
-            prop_assert!(FileTime::NT_TIME_EPOCH.checked_add(dur).is_none());
+            prop_assert!(FileTime::NT_TIME_EPOCH.checked_add(duration).is_none());
         }
     }
 
@@ -483,11 +479,11 @@ mod tests {
 
     #[cfg(feature = "std")]
     #[proptest]
-    fn checked_sub_roundtrip(dur: Duration) {
-        if dur <= Duration::new(1_844_674_407_370, 955_161_500) {
-            prop_assert!(FileTime::MAX.checked_sub(dur).is_some());
+    fn checked_sub_roundtrip(duration: Duration) {
+        if duration <= Duration::new(1_844_674_407_370, 955_161_500) {
+            prop_assert!(FileTime::MAX.checked_sub(duration).is_some());
         } else {
-            prop_assert!(FileTime::MAX.checked_sub(dur).is_none());
+            prop_assert!(FileTime::MAX.checked_sub(duration).is_none());
         }
     }
 
@@ -527,11 +523,17 @@ mod tests {
 
     #[cfg(feature = "std")]
     #[proptest]
-    fn saturating_add_roundtrip(dur: Duration) {
-        if dur <= Duration::new(1_844_674_407_370, 955_161_400) {
-            prop_assert_ne!(FileTime::NT_TIME_EPOCH.saturating_add(dur), FileTime::MAX);
+    fn saturating_add_roundtrip(duration: Duration) {
+        if duration <= Duration::new(1_844_674_407_370, 955_161_400) {
+            prop_assert_ne!(
+                FileTime::NT_TIME_EPOCH.saturating_add(duration),
+                FileTime::MAX
+            );
         } else {
-            prop_assert_eq!(FileTime::NT_TIME_EPOCH.saturating_add(dur), FileTime::MAX);
+            prop_assert_eq!(
+                FileTime::NT_TIME_EPOCH.saturating_add(duration),
+                FileTime::MAX
+            );
         }
     }
 
@@ -571,11 +573,17 @@ mod tests {
 
     #[cfg(feature = "std")]
     #[proptest]
-    fn saturating_sub_roundtrip(dur: Duration) {
-        if dur <= Duration::new(1_844_674_407_370, 955_161_400) {
-            prop_assert_ne!(FileTime::MAX.saturating_sub(dur), FileTime::NT_TIME_EPOCH);
+    fn saturating_sub_roundtrip(duration: Duration) {
+        if duration <= Duration::new(1_844_674_407_370, 955_161_400) {
+            prop_assert_ne!(
+                FileTime::MAX.saturating_sub(duration),
+                FileTime::NT_TIME_EPOCH
+            );
         } else {
-            prop_assert_eq!(FileTime::MAX.saturating_sub(dur), FileTime::NT_TIME_EPOCH);
+            prop_assert_eq!(
+                FileTime::MAX.saturating_sub(duration),
+                FileTime::NT_TIME_EPOCH
+            );
         }
     }
 

--- a/src/file_time/unix_time.rs
+++ b/src/file_time/unix_time.rs
@@ -394,7 +394,7 @@ impl FileTime {
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "std")]
-    use proptest::{prop_assert, prop_assert_eq};
+    use proptest::{prop_assert, prop_assert_eq, prop_assume};
     #[cfg(feature = "std")]
     use test_strategy::proptest;
 
@@ -445,8 +445,8 @@ mod tests {
 
     #[cfg(feature = "std")]
     #[proptest]
-    fn to_unix_time_roundtrip(ft: u64) {
-        let ts = FileTime::new(ft).to_unix_time();
+    fn to_unix_time_roundtrip(ft: FileTime) {
+        let ts = ft.to_unix_time();
         prop_assert!((-11_644_473_600..=1_833_029_933_770).contains(&ts.0));
         prop_assert!(ts.1 < NANOS_PER_SEC);
     }
@@ -506,8 +506,8 @@ mod tests {
 
     #[cfg(feature = "std")]
     #[proptest]
-    fn to_unix_time_secs_roundtrip(ft: u64) {
-        let ts = FileTime::new(ft).to_unix_time_secs();
+    fn to_unix_time_secs_roundtrip(ft: FileTime) {
+        let ts = ft.to_unix_time_secs();
         prop_assert!((-11_644_473_600..=1_833_029_933_770).contains(&ts));
     }
 
@@ -572,8 +572,8 @@ mod tests {
 
     #[cfg(feature = "std")]
     #[proptest]
-    fn to_unix_time_millis_roundtrip(ft: u64) {
-        let ts = FileTime::new(ft).to_unix_time_millis();
+    fn to_unix_time_millis_roundtrip(ft: FileTime) {
+        let ts = ft.to_unix_time_millis();
         prop_assert!((-11_644_473_600_000..=1_833_029_933_770_955).contains(&ts));
     }
 
@@ -644,8 +644,8 @@ mod tests {
 
     #[cfg(feature = "std")]
     #[proptest]
-    fn to_unix_time_micros_roundtrip(ft: u64) {
-        let ts = FileTime::new(ft).to_unix_time_micros();
+    fn to_unix_time_micros_roundtrip(ft: FileTime) {
+        let ts = ft.to_unix_time_micros();
         prop_assert!((-11_644_473_600_000_000..=1_833_029_933_770_955_161).contains(&ts));
     }
 
@@ -692,8 +692,8 @@ mod tests {
 
     #[cfg(feature = "std")]
     #[proptest]
-    fn to_unix_time_nanos_roundtrip(ft: u64) {
-        let ts = FileTime::new(ft).to_unix_time_nanos();
+    fn to_unix_time_nanos_roundtrip(ft: FileTime) {
+        let ts = ft.to_unix_time_nanos();
         prop_assert!((-11_644_473_600_000_000_000..=1_833_029_933_770_955_161_500).contains(&ts));
     }
 
@@ -847,8 +847,6 @@ mod tests {
         #[strategy(-11_644_473_600..=1_833_029_933_770_i64)] secs: i64,
         #[strategy(..NANOS_PER_SEC)] nanos: u32,
     ) {
-        use proptest::{prop_assert, prop_assume};
-
         if secs == 1_833_029_933_770 {
             prop_assume!(nanos < 955_161_600);
         }
@@ -898,8 +896,6 @@ mod tests {
         #[strategy(1_833_029_933_770_i64..)] secs: i64,
         #[strategy(..NANOS_PER_SEC)] nanos: u32,
     ) {
-        use proptest::{prop_assert_eq, prop_assume};
-
         if secs == 1_833_029_933_770 {
             prop_assume!(nanos >= 955_161_600);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //!     Ok(utc_datetime!(1601-01-01 00:00:00))
 //! );
 //!
-//! let ft = ft + Duration::from_secs(11_644_473_600);
+//! let ft = ft + Duration::from_hours(3_234_576);
 //! assert_eq!(UtcDateTime::try_from(ft), Ok(UtcDateTime::UNIX_EPOCH));
 //! assert_eq!(ft.to_raw(), 116_444_736_000_000_000);
 //!


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
These methods are inspired by [`jiff::Timestamp::as_duration`](https://docs.rs/jiff/0.2.20/jiff/struct.Timestamp.html#method.as_duration) and [`jiff::Timestamp::from_duration`](https://docs.rs/jiff/0.2.20/jiff/struct.Timestamp.html#method.from_duration).

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
