### PR TITLE
test: Fix `try_from_system_time_to_file_time_before_nt_time_epoch`

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -38,7 +38,7 @@ jobs:
             os: windows-2025
             target: x86_64-pc-windows-msvc
           - toolchain-alias: msrv
-            toolchain: 1.93.0
+            toolchain: 1.94.0
           - toolchain-alias: stable
             toolchain: stable
     steps:
@@ -91,7 +91,7 @@ jobs:
             os: windows-2025
             target: x86_64-pc-windows-msvc
           - toolchain-alias: msrv
-            toolchain: 1.93.0
+            toolchain: 1.94.0
           - toolchain-alias: stable
             toolchain: stable
     steps:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/[Keep a Changelog], and this
 project adheres to https://semver.org/[Semantic Versioning].
 
+== {compare-url}/v0.15.0\...HEAD[Unreleased]
+
+=== Changed
+
+* Bump MSRV to 1.94.0 ({pull-request-url}/461[#461])
+
 == {compare-url}/v0.14.0\...v0.15.0[0.15.0] - 2026-02-28
 
 === Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 name = "nt-time"
 version = "0.15.0"
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.94.0"
 description = "A Windows file time library"
 documentation = "https://docs.rs/nt-time"
 repository = "https://github.com/sorairolake/nt-time"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See the [documentation][docs-url] for more details.
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version (MSRV) of this library is v1.93.0.
+The minimum supported Rust version (MSRV) of this library is v1.94.0.
 
 ## Source code
 

--- a/src/file_time/convert.rs
+++ b/src/file_time/convert.rs
@@ -263,9 +263,10 @@ impl TryFrom<SystemTime> for FileTime {
     /// );
     ///
     /// // Before `1601-01-01 00:00:00 UTC`.
+    /// #[cfg(not(windows))]
     /// assert!(
     ///     FileTime::try_from(
-    ///         SystemTime::UNIX_EPOCH - Duration::from_nanos(11_644_473_600_000_000_100)
+    ///         SystemTime::UNIX_EPOCH - Duration::from_nanos(11_644_473_600_000_000_001)
     ///     )
     ///     .is_err()
     /// );
@@ -711,14 +712,13 @@ mod tests {
     }
 
     #[cfg(feature = "std")]
+    #[cfg(not(windows))]
     #[test]
     fn try_from_system_time_to_file_time_before_nt_time_epoch() {
         assert_eq!(
-            FileTime::try_from(if cfg!(windows) {
-                SystemTime::UNIX_EPOCH - Duration::from_nanos(11_644_473_600_000_000_100)
-            } else {
+            FileTime::try_from(
                 SystemTime::UNIX_EPOCH - Duration::from_nanos(11_644_473_600_000_000_001)
-            })
+            )
             .unwrap_err(),
             FileTimeRangeErrorKind::Negative.into()
         );


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
On Windows `std::time::SystemTime::checked_sub_duration` will return `None` for times before the NT time epoch.

See rust-lang/rust#148825

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
