### PR TITLE
test: Change to use `FileTime::SIGNED_MAX`

### DIFF
--- a/benches/ops.rs
+++ b/benches/ops.rs
@@ -125,7 +125,7 @@ fn sub_negative_jiff_span(b: &mut Bencher) {
 fn sub_file_time_from_system_time(b: &mut Bencher) {
     b.iter(|| {
         (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700))
-            - FileTime::new(9_223_372_036_854_775_806)
+            - FileTime::new(i64::MAX as u64 - 1)
     });
 }
 
@@ -133,7 +133,7 @@ fn sub_file_time_from_system_time(b: &mut Bencher) {
 #[bench]
 fn sub_system_time_from_file_time(b: &mut Bencher) {
     b.iter(|| {
-        FileTime::new(9_223_372_036_854_775_807)
+        FileTime::SIGNED_MAX
             - (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_600))
     });
 }

--- a/src/file_time/cmp.rs
+++ b/src/file_time/cmp.rs
@@ -163,11 +163,11 @@ mod tests {
     fn equality_system_time_and_file_time() {
         assert_eq!(
             (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700)),
-            FileTime::new(9_223_372_036_854_775_807)
+            FileTime::SIGNED_MAX
         );
         assert_ne!(
             (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700)),
-            FileTime::new(9_223_372_036_854_775_806)
+            FileTime::new(i64::MAX as u64 - 1)
         );
         assert_eq!(SystemTime::UNIX_EPOCH, FileTime::UNIX_EPOCH);
         assert_ne!(SystemTime::UNIX_EPOCH, FileTime::NT_TIME_EPOCH);
@@ -177,11 +177,11 @@ mod tests {
     #[test]
     fn equality_file_time_and_system_time() {
         assert_eq!(
-            FileTime::new(9_223_372_036_854_775_807),
+            FileTime::SIGNED_MAX,
             (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700))
         );
         assert_ne!(
-            FileTime::new(9_223_372_036_854_775_806),
+            FileTime::new(i64::MAX as u64 - 1),
             (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700))
         );
         assert_eq!(FileTime::UNIX_EPOCH, SystemTime::UNIX_EPOCH);
@@ -311,7 +311,7 @@ mod tests {
     #[cfg(feature = "std")]
     #[test]
     fn order_system_time_and_file_time() {
-        assert!(SystemTime::UNIX_EPOCH < FileTime::new(9_223_372_036_854_775_807));
+        assert!(SystemTime::UNIX_EPOCH < FileTime::SIGNED_MAX);
         assert_eq!(
             SystemTime::UNIX_EPOCH.partial_cmp(&FileTime::UNIX_EPOCH),
             Some(Ordering::Equal)

--- a/src/file_time/convert.rs
+++ b/src/file_time/convert.rs
@@ -512,7 +512,7 @@ mod tests {
         );
         // Largest `SystemTime` on Windows.
         assert_eq!(
-            SystemTime::from(FileTime::new(9_223_372_036_854_775_807)),
+            SystemTime::from(FileTime::SIGNED_MAX),
             SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700)
         );
         if !cfg!(windows) {
@@ -753,7 +753,7 @@ mod tests {
                 SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700)
             )
             .unwrap(),
-            FileTime::new(9_223_372_036_854_775_807)
+            FileTime::SIGNED_MAX
         );
         if !cfg!(windows) {
             assert_eq!(

--- a/src/file_time/ops.rs
+++ b/src/file_time/ops.rs
@@ -1391,12 +1391,12 @@ mod tests {
     fn sub_file_time_from_system_time() {
         assert_eq!(
             (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700))
-                - FileTime::new(9_223_372_036_854_775_807),
+                - FileTime::SIGNED_MAX,
             Duration::ZERO
         );
         assert_eq!(
             (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700))
-                - FileTime::new(9_223_372_036_854_775_806),
+                - FileTime::new(i64::MAX as u64 - 1),
             Duration::from_nanos(100)
         );
         assert_eq!(
@@ -1410,7 +1410,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn sub_file_time_from_system_time_with_overflow() {
-        let _ = FileTime::new(9_223_372_036_854_775_806)
+        let _ = FileTime::new(i64::MAX as u64 - 1)
             - (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700));
     }
 
@@ -1418,27 +1418,27 @@ mod tests {
     #[test]
     fn sub_system_time_from_file_time() {
         assert_eq!(
-            FileTime::new(9_223_372_036_854_775_807)
+            FileTime::SIGNED_MAX
                 - (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_700)),
             Duration::ZERO
         );
         assert_eq!(
-            FileTime::new(9_223_372_036_854_775_807)
+            FileTime::SIGNED_MAX
                 - (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_699)),
             Duration::from_nanos(if cfg!(windows) { 100 } else { 1 })
         );
         assert_eq!(
-            FileTime::new(9_223_372_036_854_775_807)
+            FileTime::SIGNED_MAX
                 - (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_601)),
             Duration::from_nanos(if cfg!(windows) { 100 } else { 99 })
         );
         assert_eq!(
-            FileTime::new(9_223_372_036_854_775_807)
+            FileTime::SIGNED_MAX
                 - (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_600)),
             Duration::from_nanos(100)
         );
         assert_eq!(
-            FileTime::new(9_223_372_036_854_775_807) - SystemTime::UNIX_EPOCH,
+            FileTime::SIGNED_MAX - SystemTime::UNIX_EPOCH,
             Duration::new(910_692_730_085, 477_580_700)
         );
     }
@@ -1448,7 +1448,7 @@ mod tests {
     #[should_panic]
     fn sub_system_time_from_file_time_with_overflow() {
         let _ = (SystemTime::UNIX_EPOCH + Duration::new(910_692_730_085, 477_580_600))
-            - FileTime::new(9_223_372_036_854_775_807);
+            - FileTime::SIGNED_MAX;
     }
 
     #[test]


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
