### PR TITLE
Revert "test: restore `try_from_file_time_to_jiff_timestamp_with_invalid_file…"

### DIFF
--- a/src/file_time/convert.rs
+++ b/src/file_time/convert.rs
@@ -162,10 +162,6 @@ impl TryFrom<FileTime> for Timestamp {
     ///
     /// Returns [`Err`] if `ft` is out of range for [`Timestamp`].
     ///
-    /// # Panics
-    ///
-    /// Panics if the resulting timestamp is greater than [`Timestamp::MAX`].
-    ///
     /// # Examples
     ///
     /// ```
@@ -603,13 +599,6 @@ mod tests {
             Timestamp::try_from(FileTime::new(2_650_466_808_009_999_999)).unwrap(),
             Timestamp::MAX - 99.nanoseconds()
         );
-    }
-
-    #[cfg(feature = "jiff")]
-    #[test]
-    #[should_panic]
-    fn try_from_file_time_to_jiff_timestamp_with_invalid_file_time() {
-        let _ = Timestamp::try_from(FileTime::new(2_650_466_808_010_000_000));
     }
 
     #[cfg(feature = "dos-date-time")]


### PR DESCRIPTION
Reverts sorairolake/nt-time#519