### PR TITLE
style: remove import of `jiff::Timestamp`

### DIFF
--- a/benches/cmp.rs
+++ b/benches/cmp.rs
@@ -11,8 +11,6 @@ use std::time::SystemTime;
 
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, TimeZone, Utc};
-#[cfg(feature = "jiff")]
-use jiff::Timestamp;
 use nt_time::{
     FileTime,
     time::{UtcDateTime, macros::utc_datetime},
@@ -66,13 +64,13 @@ fn equality_file_time_and_chrono_date_time(b: &mut Bencher) {
 #[cfg(feature = "jiff")]
 #[bench]
 fn equality_jiff_timestamp_and_file_time(b: &mut Bencher) {
-    b.iter(|| Timestamp::from_second(-11_644_473_600).unwrap() == FileTime::NT_TIME_EPOCH);
+    b.iter(|| jiff::Timestamp::from_second(-11_644_473_600).unwrap() == FileTime::NT_TIME_EPOCH);
 }
 
 #[cfg(feature = "jiff")]
 #[bench]
 fn equality_file_time_and_jiff_timestamp(b: &mut Bencher) {
-    b.iter(|| FileTime::NT_TIME_EPOCH == Timestamp::from_second(-11_644_473_600).unwrap());
+    b.iter(|| FileTime::NT_TIME_EPOCH == jiff::Timestamp::from_second(-11_644_473_600).unwrap());
 }
 
 #[cfg(feature = "std")]
@@ -112,11 +110,11 @@ fn order_file_time_and_chrono_date_time(b: &mut Bencher) {
 #[cfg(feature = "jiff")]
 #[bench]
 fn order_jiff_timestamp_and_file_time(b: &mut Bencher) {
-    b.iter(|| Timestamp::UNIX_EPOCH > FileTime::NT_TIME_EPOCH);
+    b.iter(|| jiff::Timestamp::UNIX_EPOCH > FileTime::NT_TIME_EPOCH);
 }
 
 #[cfg(feature = "jiff")]
 #[bench]
 fn order_file_time_and_jiff_timestamp(b: &mut Bencher) {
-    b.iter(|| FileTime::UNIX_EPOCH > Timestamp::from_second(-11_644_473_600).unwrap());
+    b.iter(|| FileTime::UNIX_EPOCH > jiff::Timestamp::from_second(-11_644_473_600).unwrap());
 }

--- a/benches/convert.rs
+++ b/benches/convert.rs
@@ -9,8 +9,6 @@ extern crate test;
 #[cfg(feature = "std")]
 use std::time::SystemTime;
 
-#[cfg(feature = "jiff")]
-use jiff::Timestamp;
 use nt_time::{FileTime, time::UtcDateTime};
 use test::Bencher;
 
@@ -39,7 +37,7 @@ fn from_file_time_to_chrono_date_time(b: &mut Bencher) {
 #[cfg(feature = "jiff")]
 #[bench]
 fn try_from_file_time_to_jiff_timestamp(b: &mut Bencher) {
-    b.iter(|| Timestamp::try_from(FileTime::UNIX_EPOCH).unwrap());
+    b.iter(|| jiff::Timestamp::try_from(FileTime::UNIX_EPOCH).unwrap());
 }
 
 #[cfg(feature = "dos-date-time")]
@@ -73,7 +71,7 @@ fn try_from_chrono_date_time_to_file_time(b: &mut Bencher) {
 #[cfg(feature = "jiff")]
 #[bench]
 fn try_from_jiff_timestamp_to_file_time(b: &mut Bencher) {
-    b.iter(|| FileTime::try_from(Timestamp::UNIX_EPOCH).unwrap());
+    b.iter(|| FileTime::try_from(jiff::Timestamp::UNIX_EPOCH).unwrap());
 }
 
 #[cfg(feature = "dos-date-time")]

--- a/benches/ops.rs
+++ b/benches/ops.rs
@@ -13,7 +13,7 @@ use std::time::SystemTime;
 #[cfg(feature = "chrono")]
 use chrono::{TimeDelta, TimeZone, Timelike, Utc};
 #[cfg(feature = "jiff")]
-use jiff::{Timestamp, ToSpan};
+use jiff::ToSpan;
 use nt_time::{FileTime, time::macros::utc_datetime};
 use test::Bencher;
 
@@ -169,13 +169,13 @@ fn sub_chrono_date_time_from_file_time(b: &mut Bencher) {
 #[cfg(feature = "jiff")]
 #[bench]
 fn sub_file_time_from_jiff_timestamp(b: &mut Bencher) {
-    b.iter(|| (Timestamp::MAX - 99.nanoseconds()) - FileTime::NT_TIME_EPOCH);
+    b.iter(|| (jiff::Timestamp::MAX - 99.nanoseconds()) - FileTime::NT_TIME_EPOCH);
 }
 
 #[cfg(feature = "jiff")]
 #[bench]
 fn sub_jiff_timestamp_from_file_time(b: &mut Bencher) {
     b.iter(|| {
-        FileTime::new(2_650_466_808_009_999_999) - Timestamp::from_second(-11_644_473_600).unwrap()
+        FileTime::new(2_650_466_808_009_999_999) - jiff::Timestamp::from_second(-11_644_473_600).unwrap()
     });
 }

--- a/benches/ops.rs
+++ b/benches/ops.rs
@@ -176,6 +176,7 @@ fn sub_file_time_from_jiff_timestamp(b: &mut Bencher) {
 #[bench]
 fn sub_jiff_timestamp_from_file_time(b: &mut Bencher) {
     b.iter(|| {
-        FileTime::new(2_650_466_808_009_999_999) - jiff::Timestamp::from_second(-11_644_473_600).unwrap()
+        FileTime::new(2_650_466_808_009_999_999)
+            - jiff::Timestamp::from_second(-11_644_473_600).unwrap()
     });
 }

--- a/src/file_time/cmp.rs
+++ b/src/file_time/cmp.rs
@@ -283,7 +283,10 @@ mod tests {
             jiff::Timestamp::MAX - 99.nanoseconds(),
             FileTime::new(2_650_466_808_009_999_999)
         );
-        assert_ne!(jiff::Timestamp::MAX - 99.nanoseconds(), FileTime::NT_TIME_EPOCH);
+        assert_ne!(
+            jiff::Timestamp::MAX - 99.nanoseconds(),
+            FileTime::NT_TIME_EPOCH
+        );
         assert_ne!(
             jiff::Timestamp::from_second(-11_644_473_600).unwrap(),
             FileTime::new(2_650_466_808_009_999_999)
@@ -301,7 +304,10 @@ mod tests {
             FileTime::new(2_650_466_808_009_999_999),
             jiff::Timestamp::MAX - 99.nanoseconds()
         );
-        assert_ne!(FileTime::NT_TIME_EPOCH, jiff::Timestamp::MAX - 99.nanoseconds());
+        assert_ne!(
+            FileTime::NT_TIME_EPOCH,
+            jiff::Timestamp::MAX - 99.nanoseconds()
+        );
         assert_ne!(
             FileTime::new(2_650_466_808_009_999_999),
             jiff::Timestamp::from_second(-11_644_473_600).unwrap()

--- a/src/file_time/cmp.rs
+++ b/src/file_time/cmp.rs
@@ -10,8 +10,6 @@ use std::time::SystemTime;
 
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, Utc};
-#[cfg(feature = "jiff")]
-use jiff::Timestamp;
 use time::UtcDateTime;
 
 use super::FileTime;
@@ -57,16 +55,16 @@ impl PartialEq<DateTime<Utc>> for FileTime {
 }
 
 #[cfg(feature = "jiff")]
-impl PartialEq<FileTime> for Timestamp {
+impl PartialEq<FileTime> for jiff::Timestamp {
     fn eq(&self, other: &FileTime) -> bool {
         self == &Self::try_from(*other).unwrap()
     }
 }
 
 #[cfg(feature = "jiff")]
-impl PartialEq<Timestamp> for FileTime {
-    fn eq(&self, other: &Timestamp) -> bool {
-        &Timestamp::try_from(*self).unwrap() == other
+impl PartialEq<jiff::Timestamp> for FileTime {
+    fn eq(&self, other: &jiff::Timestamp) -> bool {
+        &jiff::Timestamp::try_from(*self).unwrap() == other
     }
 }
 
@@ -111,16 +109,16 @@ impl PartialOrd<DateTime<Utc>> for FileTime {
 }
 
 #[cfg(feature = "jiff")]
-impl PartialOrd<FileTime> for Timestamp {
+impl PartialOrd<FileTime> for jiff::Timestamp {
     fn partial_cmp(&self, other: &FileTime) -> Option<Ordering> {
         self.partial_cmp(&Self::try_from(*other).unwrap())
     }
 }
 
 #[cfg(feature = "jiff")]
-impl PartialOrd<Timestamp> for FileTime {
-    fn partial_cmp(&self, other: &Timestamp) -> Option<Ordering> {
-        Timestamp::try_from(*self).unwrap().partial_cmp(other)
+impl PartialOrd<jiff::Timestamp> for FileTime {
+    fn partial_cmp(&self, other: &jiff::Timestamp) -> Option<Ordering> {
+        jiff::Timestamp::try_from(*self).unwrap().partial_cmp(other)
     }
 }
 
@@ -282,16 +280,16 @@ mod tests {
     #[test]
     fn equality_jiff_timestamp_and_file_time() {
         assert_eq!(
-            Timestamp::MAX - 99.nanoseconds(),
+            jiff::Timestamp::MAX - 99.nanoseconds(),
             FileTime::new(2_650_466_808_009_999_999)
         );
-        assert_ne!(Timestamp::MAX - 99.nanoseconds(), FileTime::NT_TIME_EPOCH);
+        assert_ne!(jiff::Timestamp::MAX - 99.nanoseconds(), FileTime::NT_TIME_EPOCH);
         assert_ne!(
-            Timestamp::from_second(-11_644_473_600).unwrap(),
+            jiff::Timestamp::from_second(-11_644_473_600).unwrap(),
             FileTime::new(2_650_466_808_009_999_999)
         );
         assert_eq!(
-            Timestamp::from_second(-11_644_473_600).unwrap(),
+            jiff::Timestamp::from_second(-11_644_473_600).unwrap(),
             FileTime::NT_TIME_EPOCH
         );
     }
@@ -301,16 +299,16 @@ mod tests {
     fn equality_file_time_and_jiff_timestamp() {
         assert_eq!(
             FileTime::new(2_650_466_808_009_999_999),
-            Timestamp::MAX - 99.nanoseconds()
+            jiff::Timestamp::MAX - 99.nanoseconds()
         );
-        assert_ne!(FileTime::NT_TIME_EPOCH, Timestamp::MAX - 99.nanoseconds());
+        assert_ne!(FileTime::NT_TIME_EPOCH, jiff::Timestamp::MAX - 99.nanoseconds());
         assert_ne!(
             FileTime::new(2_650_466_808_009_999_999),
-            Timestamp::from_second(-11_644_473_600).unwrap()
+            jiff::Timestamp::from_second(-11_644_473_600).unwrap()
         );
         assert_eq!(
             FileTime::NT_TIME_EPOCH,
-            Timestamp::from_second(-11_644_473_600).unwrap()
+            jiff::Timestamp::from_second(-11_644_473_600).unwrap()
         );
     }
 
@@ -393,22 +391,22 @@ mod tests {
     #[cfg(feature = "jiff")]
     #[test]
     fn order_jiff_timestamp_and_file_time() {
-        assert!(Timestamp::UNIX_EPOCH < FileTime::new(2_650_466_808_009_999_999));
+        assert!(jiff::Timestamp::UNIX_EPOCH < FileTime::new(2_650_466_808_009_999_999));
         assert_eq!(
-            Timestamp::UNIX_EPOCH.partial_cmp(&FileTime::UNIX_EPOCH),
+            jiff::Timestamp::UNIX_EPOCH.partial_cmp(&FileTime::UNIX_EPOCH),
             Some(Ordering::Equal)
         );
-        assert!(Timestamp::UNIX_EPOCH > FileTime::NT_TIME_EPOCH);
+        assert!(jiff::Timestamp::UNIX_EPOCH > FileTime::NT_TIME_EPOCH);
     }
 
     #[cfg(feature = "jiff")]
     #[test]
     fn order_file_time_and_jiff_timestamp() {
-        assert!(FileTime::UNIX_EPOCH < Timestamp::MAX);
+        assert!(FileTime::UNIX_EPOCH < jiff::Timestamp::MAX);
         assert_eq!(
-            FileTime::UNIX_EPOCH.partial_cmp(&Timestamp::UNIX_EPOCH),
+            FileTime::UNIX_EPOCH.partial_cmp(&jiff::Timestamp::UNIX_EPOCH),
             Some(Ordering::Equal)
         );
-        assert!(FileTime::UNIX_EPOCH > Timestamp::from_second(-11_644_473_600).unwrap());
+        assert!(FileTime::UNIX_EPOCH > jiff::Timestamp::from_second(-11_644_473_600).unwrap());
     }
 }

--- a/src/file_time/convert.rs
+++ b/src/file_time/convert.rs
@@ -900,8 +900,10 @@ mod tests {
     #[test]
     fn try_from_jiff_timestamp_to_file_time_before_nt_time_epoch() {
         assert_eq!(
-            FileTime::try_from(jiff::Timestamp::from_nanosecond(-11_644_473_600_000_000_001).unwrap())
-                .unwrap_err(),
+            FileTime::try_from(
+                jiff::Timestamp::from_nanosecond(-11_644_473_600_000_000_001).unwrap()
+            )
+            .unwrap_err(),
             FileTimeRangeErrorKind::Negative.into()
         );
     }

--- a/src/file_time/convert.rs
+++ b/src/file_time/convert.rs
@@ -14,8 +14,6 @@ use dos_date_time::{
     error::{DateTimeRangeError, DateTimeRangeErrorKind},
     time::PrimitiveDateTime,
 };
-#[cfg(feature = "jiff")]
-use jiff::Timestamp;
 use time::{UtcDateTime, error::ComponentRange};
 
 use super::FileTime;
@@ -153,14 +151,14 @@ impl From<FileTime> for chrono::DateTime<Utc> {
 }
 
 #[cfg(feature = "jiff")]
-impl TryFrom<FileTime> for Timestamp {
+impl TryFrom<FileTime> for jiff::Timestamp {
     type Error = jiff::Error;
 
-    /// Converts a `FileTime` to a [`Timestamp`].
+    /// Converts a `FileTime` to a [`jiff::Timestamp`].
     ///
     /// # Errors
     ///
-    /// Returns [`Err`] if `ft` is out of range for [`Timestamp`].
+    /// Returns [`Err`] if `ft` is out of range for [`jiff::Timestamp`].
     ///
     /// # Examples
     ///
@@ -380,10 +378,10 @@ impl TryFrom<chrono::DateTime<Utc>> for FileTime {
 }
 
 #[cfg(feature = "jiff")]
-impl TryFrom<Timestamp> for FileTime {
+impl TryFrom<jiff::Timestamp> for FileTime {
     type Error = FileTimeRangeError;
 
-    /// Converts a [`Timestamp`] to a `FileTime`.
+    /// Converts a [`jiff::Timestamp`] to a `FileTime`.
     ///
     /// # Errors
     ///
@@ -409,7 +407,7 @@ impl TryFrom<Timestamp> for FileTime {
     ///         .is_err()
     /// );
     /// ```
-    fn try_from(ts: Timestamp) -> Result<Self, Self::Error> {
+    fn try_from(ts: jiff::Timestamp) -> Result<Self, Self::Error> {
         Self::from_unix_time_nanos(ts.as_nanosecond())
     }
 }
@@ -590,23 +588,23 @@ mod tests {
     #[test]
     fn try_from_file_time_to_jiff_timestamp() {
         assert_eq!(
-            Timestamp::try_from(FileTime::NT_TIME_EPOCH).unwrap(),
-            Timestamp::from_second(-11_644_473_600).unwrap()
+            jiff::Timestamp::try_from(FileTime::NT_TIME_EPOCH).unwrap(),
+            jiff::Timestamp::from_second(-11_644_473_600).unwrap()
         );
         assert_eq!(
-            Timestamp::try_from(FileTime::UNIX_EPOCH).unwrap(),
-            Timestamp::UNIX_EPOCH
+            jiff::Timestamp::try_from(FileTime::UNIX_EPOCH).unwrap(),
+            jiff::Timestamp::UNIX_EPOCH
         );
         assert_eq!(
-            Timestamp::try_from(FileTime::new(2_650_466_808_009_999_999)).unwrap(),
-            Timestamp::MAX - 99.nanoseconds()
+            jiff::Timestamp::try_from(FileTime::new(2_650_466_808_009_999_999)).unwrap(),
+            jiff::Timestamp::MAX - 99.nanoseconds()
         );
     }
 
     #[cfg(feature = "jiff")]
     #[test]
     fn try_from_file_time_to_jiff_timestamp_with_invalid_file_time() {
-        assert!(Timestamp::try_from(FileTime::new(2_650_466_808_010_000_000)).is_err());
+        assert!(jiff::Timestamp::try_from(FileTime::new(2_650_466_808_010_000_000)).is_err());
     }
 
     #[cfg(feature = "dos-date-time")]
@@ -902,7 +900,7 @@ mod tests {
     #[test]
     fn try_from_jiff_timestamp_to_file_time_before_nt_time_epoch() {
         assert_eq!(
-            FileTime::try_from(Timestamp::from_nanosecond(-11_644_473_600_000_000_001).unwrap())
+            FileTime::try_from(jiff::Timestamp::from_nanosecond(-11_644_473_600_000_000_001).unwrap())
                 .unwrap_err(),
             FileTimeRangeErrorKind::Negative.into()
         );
@@ -912,15 +910,15 @@ mod tests {
     #[test]
     fn try_from_jiff_timestamp_to_file_time() {
         assert_eq!(
-            FileTime::try_from(Timestamp::from_second(-11_644_473_600).unwrap()).unwrap(),
+            FileTime::try_from(jiff::Timestamp::from_second(-11_644_473_600).unwrap()).unwrap(),
             FileTime::NT_TIME_EPOCH
         );
         assert_eq!(
-            FileTime::try_from(Timestamp::UNIX_EPOCH).unwrap(),
+            FileTime::try_from(jiff::Timestamp::UNIX_EPOCH).unwrap(),
             FileTime::UNIX_EPOCH
         );
         assert_eq!(
-            FileTime::try_from(Timestamp::MAX).unwrap(),
+            FileTime::try_from(jiff::Timestamp::MAX).unwrap(),
             FileTime::new(2_650_466_808_009_999_999)
         );
     }

--- a/src/file_time/ops.rs
+++ b/src/file_time/ops.rs
@@ -14,7 +14,7 @@ use std::time::SystemTime;
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, TimeDelta, Utc};
 #[cfg(feature = "jiff")]
-use jiff::{Span, Timestamp};
+use jiff::Span;
 use time::UtcDateTime;
 
 use super::FileTime;
@@ -336,7 +336,7 @@ impl Sub<DateTime<Utc>> for FileTime {
 }
 
 #[cfg(feature = "jiff")]
-impl Sub<FileTime> for Timestamp {
+impl Sub<FileTime> for jiff::Timestamp {
     type Output = Span;
 
     fn sub(self, rhs: FileTime) -> Self::Output {
@@ -345,11 +345,11 @@ impl Sub<FileTime> for Timestamp {
 }
 
 #[cfg(feature = "jiff")]
-impl Sub<Timestamp> for FileTime {
+impl Sub<jiff::Timestamp> for FileTime {
     type Output = Span;
 
-    fn sub(self, rhs: Timestamp) -> Self::Output {
-        Timestamp::try_from(self).unwrap() - rhs
+    fn sub(self, rhs: jiff::Timestamp) -> Self::Output {
+        jiff::Timestamp::try_from(self).unwrap() - rhs
     }
 }
 
@@ -1582,16 +1582,16 @@ mod tests {
     #[test]
     fn sub_file_time_from_jiff_timestamp() {
         assert_eq!(
-            (Timestamp::MAX - 99.nanoseconds()) - FileTime::new(2_650_466_808_009_999_999),
+            (jiff::Timestamp::MAX - 99.nanoseconds()) - FileTime::new(2_650_466_808_009_999_999),
             Span::new().fieldwise()
         );
         assert_eq!(
-            (Timestamp::MAX - 99.nanoseconds())
+            (jiff::Timestamp::MAX - 99.nanoseconds())
                 - (FileTime::new(2_650_466_808_009_999_999) - 100.nanoseconds()),
             100.nanoseconds().fieldwise()
         );
         assert_eq!(
-            (Timestamp::MAX - 99.nanoseconds()) - FileTime::NT_TIME_EPOCH,
+            (jiff::Timestamp::MAX - 99.nanoseconds()) - FileTime::NT_TIME_EPOCH,
             265_046_680_800_i64
                 .seconds()
                 .milliseconds(999)
@@ -1605,27 +1605,27 @@ mod tests {
     #[test]
     fn sub_jiff_timestamp_from_file_time() {
         assert_eq!(
-            FileTime::new(2_650_466_808_009_999_999) - (Timestamp::MAX - 99.nanoseconds()),
+            FileTime::new(2_650_466_808_009_999_999) - (jiff::Timestamp::MAX - 99.nanoseconds()),
             Span::new().fieldwise()
         );
         assert_eq!(
             FileTime::new(2_650_466_808_009_999_999)
-                - ((Timestamp::MAX - 99.nanoseconds()) - 1.nanosecond()),
+                - ((jiff::Timestamp::MAX - 99.nanoseconds()) - 1.nanosecond()),
             1.nanosecond().fieldwise()
         );
         assert_eq!(
             FileTime::new(2_650_466_808_009_999_999)
-                - ((Timestamp::MAX - 99.nanoseconds()) - 99.nanoseconds()),
+                - ((jiff::Timestamp::MAX - 99.nanoseconds()) - 99.nanoseconds()),
             99.nanoseconds().fieldwise()
         );
         assert_eq!(
             FileTime::new(2_650_466_808_009_999_999)
-                - ((Timestamp::MAX - 99.nanoseconds()) - 100.nanoseconds()),
+                - ((jiff::Timestamp::MAX - 99.nanoseconds()) - 100.nanoseconds()),
             100.nanoseconds().fieldwise()
         );
         assert_eq!(
             FileTime::new(2_650_466_808_009_999_999)
-                - Timestamp::from_second(-11_644_473_600).unwrap(),
+                - jiff::Timestamp::from_second(-11_644_473_600).unwrap(),
             265_046_680_800_i64
                 .seconds()
                 .milliseconds(999)


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
