### PR TITLE
chore: replace `time::PrimitiveDateTime` with `time::PlainDateTime`

### DIFF
--- a/src/file_time/convert.rs
+++ b/src/file_time/convert.rs
@@ -12,7 +12,7 @@ use chrono::Utc;
 #[cfg(feature = "dos-date-time")]
 use dos_date_time::{
     error::{DateTimeRangeError, DateTimeRangeErrorKind},
-    time::PrimitiveDateTime,
+    time::PlainDateTime,
 };
 use time::{UtcDateTime, error::ComponentRange};
 
@@ -436,7 +436,7 @@ impl From<dos_date_time::DateTime> for FileTime {
     /// );
     /// ```
     fn from(dt: dos_date_time::DateTime) -> Self {
-        let dt = PrimitiveDateTime::from(dt).as_utc();
+        let dt = PlainDateTime::from(dt).as_utc();
         Self::try_from(dt).unwrap()
     }
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
`time::PrimitiveDateTime` is an alias for `time::PlainDateTime`.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
