### PR TITLE
chore: replace `time::Duration` with `time::SignedDuration`

### DIFF
--- a/benches/ops.rs
+++ b/benches/ops.rs
@@ -43,13 +43,13 @@ fn add_std_duration(b: &mut Bencher) {
 }
 
 #[bench]
-fn add_positive_time_duration(b: &mut Bencher) {
-    b.iter(|| FileTime::NT_TIME_EPOCH + time::Duration::nanoseconds(100));
+fn add_positive_time_signed_duration(b: &mut Bencher) {
+    b.iter(|| FileTime::NT_TIME_EPOCH + SignedDuration::nanoseconds(100));
 }
 
 #[bench]
-fn add_negative_time_duration(b: &mut Bencher) {
-    b.iter(|| FileTime::MAX + -time::Duration::nanoseconds(100));
+fn add_negative_time_signed_duration(b: &mut Bencher) {
+    b.iter(|| FileTime::MAX + -SignedDuration::nanoseconds(100));
 }
 
 #[cfg(feature = "chrono")]
@@ -87,13 +87,13 @@ fn sub_std_duration(b: &mut Bencher) {
 }
 
 #[bench]
-fn sub_positive_time_duration(b: &mut Bencher) {
-    b.iter(|| FileTime::MAX - time::Duration::nanoseconds(100));
+fn sub_positive_time_signed_duration(b: &mut Bencher) {
+    b.iter(|| FileTime::MAX - SignedDuration::nanoseconds(100));
 }
 
 #[bench]
-fn sub_negative_time_duration(b: &mut Bencher) {
-    b.iter(|| FileTime::NT_TIME_EPOCH - -time::Duration::nanoseconds(100));
+fn sub_negative_time_signed_duration(b: &mut Bencher) {
+    b.iter(|| FileTime::NT_TIME_EPOCH - -SignedDuration::nanoseconds(100));
 }
 
 #[cfg(feature = "chrono")]

--- a/benches/ops.rs
+++ b/benches/ops.rs
@@ -14,7 +14,10 @@ use std::time::SystemTime;
 use chrono::{TimeDelta, TimeZone, Timelike, Utc};
 #[cfg(feature = "jiff")]
 use jiff::ToSpan;
-use nt_time::{FileTime, time::macros::utc_datetime};
+use nt_time::{
+    FileTime,
+    time::{SignedDuration, macros::utc_datetime},
+};
 use test::Bencher;
 
 #[bench]

--- a/src/file_time/ops.rs
+++ b/src/file_time/ops.rs
@@ -15,7 +15,7 @@ use std::time::SystemTime;
 use chrono::{DateTime, TimeDelta, Utc};
 #[cfg(feature = "jiff")]
 use jiff::Span;
-use time::UtcDateTime;
+use time::{SignedDuration, UtcDateTime};
 
 use super::FileTime;
 

--- a/src/file_time/ops.rs
+++ b/src/file_time/ops.rs
@@ -164,10 +164,10 @@ impl Add<Duration> for FileTime {
     }
 }
 
-impl Add<time::Duration> for FileTime {
+impl Add<SignedDuration> for FileTime {
     type Output = Self;
 
-    fn add(self, rhs: time::Duration) -> Self::Output {
+    fn add(self, rhs: SignedDuration) -> Self::Output {
         if rhs.is_positive() {
             self + rhs.unsigned_abs()
         } else {
@@ -208,8 +208,8 @@ impl AddAssign<Duration> for FileTime {
     }
 }
 
-impl AddAssign<time::Duration> for FileTime {
-    fn add_assign(&mut self, rhs: time::Duration) {
+impl AddAssign<SignedDuration> for FileTime {
+    fn add_assign(&mut self, rhs: SignedDuration) {
         *self = *self + rhs;
     }
 }
@@ -245,10 +245,10 @@ impl Sub<Duration> for FileTime {
     }
 }
 
-impl Sub<time::Duration> for FileTime {
+impl Sub<SignedDuration> for FileTime {
     type Output = Self;
 
-    fn sub(self, rhs: time::Duration) -> Self::Output {
+    fn sub(self, rhs: SignedDuration) -> Self::Output {
         if rhs.is_positive() {
             self - rhs.unsigned_abs()
         } else {
@@ -302,7 +302,7 @@ impl Sub<SystemTime> for FileTime {
 }
 
 impl Sub<FileTime> for UtcDateTime {
-    type Output = time::Duration;
+    type Output = SignedDuration;
 
     fn sub(self, rhs: FileTime) -> Self::Output {
         self - Self::try_from(rhs).unwrap()
@@ -310,7 +310,7 @@ impl Sub<FileTime> for UtcDateTime {
 }
 
 impl Sub<UtcDateTime> for FileTime {
-    type Output = time::Duration;
+    type Output = SignedDuration;
 
     fn sub(self, rhs: UtcDateTime) -> Self::Output {
         UtcDateTime::try_from(self).unwrap() - rhs
@@ -359,8 +359,8 @@ impl SubAssign<Duration> for FileTime {
     }
 }
 
-impl SubAssign<time::Duration> for FileTime {
-    fn sub_assign(&mut self, rhs: time::Duration) {
+impl SubAssign<SignedDuration> for FileTime {
+    fn sub_assign(&mut self, rhs: SignedDuration) {
         *self = *self - rhs;
     }
 }
@@ -615,69 +615,69 @@ mod tests {
     }
 
     #[test]
-    fn add_positive_time_duration() {
+    fn add_positive_time_signed_duration() {
         assert_eq!(
-            FileTime::NT_TIME_EPOCH + time::Duration::ZERO,
+            FileTime::NT_TIME_EPOCH + SignedDuration::ZERO,
             FileTime::NT_TIME_EPOCH
         );
         assert_eq!(
-            FileTime::NT_TIME_EPOCH + time::Duration::NANOSECOND,
+            FileTime::NT_TIME_EPOCH + SignedDuration::NANOSECOND,
             FileTime::NT_TIME_EPOCH
         );
         assert_eq!(
-            FileTime::NT_TIME_EPOCH + time::Duration::nanoseconds(99),
+            FileTime::NT_TIME_EPOCH + SignedDuration::nanoseconds(99),
             FileTime::NT_TIME_EPOCH
         );
         assert_eq!(
-            FileTime::NT_TIME_EPOCH + time::Duration::nanoseconds(100),
+            FileTime::NT_TIME_EPOCH + SignedDuration::nanoseconds(100),
             FileTime::new(1)
         );
 
-        assert_eq!(FileTime::MAX + time::Duration::ZERO, FileTime::MAX);
-        assert_eq!(FileTime::MAX + time::Duration::NANOSECOND, FileTime::MAX);
+        assert_eq!(FileTime::MAX + SignedDuration::ZERO, FileTime::MAX);
+        assert_eq!(FileTime::MAX + SignedDuration::NANOSECOND, FileTime::MAX);
         assert_eq!(
-            FileTime::MAX + time::Duration::nanoseconds(99),
+            FileTime::MAX + SignedDuration::nanoseconds(99),
             FileTime::MAX
         );
     }
 
     #[test]
     #[should_panic]
-    fn add_positive_time_duration_with_overflow() {
-        let _ = FileTime::MAX + time::Duration::nanoseconds(100);
+    fn add_positive_time_signed_duration_with_overflow() {
+        let _ = FileTime::MAX + SignedDuration::nanoseconds(100);
     }
 
     #[test]
-    fn add_negative_time_duration() {
-        assert_eq!(FileTime::MAX + -time::Duration::ZERO, FileTime::MAX);
-        assert_eq!(FileTime::MAX + -time::Duration::NANOSECOND, FileTime::MAX);
+    fn add_negative_time_signed_duration() {
+        assert_eq!(FileTime::MAX + -SignedDuration::ZERO, FileTime::MAX);
+        assert_eq!(FileTime::MAX + -SignedDuration::NANOSECOND, FileTime::MAX);
         assert_eq!(
-            FileTime::MAX + -time::Duration::nanoseconds(99),
+            FileTime::MAX + -SignedDuration::nanoseconds(99),
             FileTime::MAX
         );
         assert_eq!(
-            FileTime::MAX + -time::Duration::nanoseconds(100),
+            FileTime::MAX + -SignedDuration::nanoseconds(100),
             FileTime::new(u64::MAX - 1)
         );
 
         assert_eq!(
-            FileTime::NT_TIME_EPOCH + -time::Duration::ZERO,
+            FileTime::NT_TIME_EPOCH + -SignedDuration::ZERO,
             FileTime::NT_TIME_EPOCH
         );
         assert_eq!(
-            FileTime::NT_TIME_EPOCH + -time::Duration::NANOSECOND,
+            FileTime::NT_TIME_EPOCH + -SignedDuration::NANOSECOND,
             FileTime::NT_TIME_EPOCH
         );
         assert_eq!(
-            FileTime::NT_TIME_EPOCH + -time::Duration::nanoseconds(99),
+            FileTime::NT_TIME_EPOCH + -SignedDuration::nanoseconds(99),
             FileTime::NT_TIME_EPOCH
         );
     }
 
     #[test]
     #[should_panic]
-    fn add_negative_time_duration_with_overflow() {
-        let _ = FileTime::NT_TIME_EPOCH + -time::Duration::nanoseconds(100);
+    fn add_negative_time_signed_duration_with_overflow() {
+        let _ = FileTime::NT_TIME_EPOCH + -SignedDuration::nanoseconds(100);
     }
 
     #[cfg(feature = "chrono")]
@@ -856,97 +856,97 @@ mod tests {
     }
 
     #[test]
-    fn add_assign_positive_time_duration() {
+    fn add_assign_positive_time_signed_duration() {
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft += time::Duration::ZERO;
+            ft += SignedDuration::ZERO;
             assert_eq!(ft, FileTime::NT_TIME_EPOCH);
         }
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft += time::Duration::NANOSECOND;
+            ft += SignedDuration::NANOSECOND;
             assert_eq!(ft, FileTime::NT_TIME_EPOCH);
         }
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft += time::Duration::nanoseconds(99);
+            ft += SignedDuration::nanoseconds(99);
             assert_eq!(ft, FileTime::NT_TIME_EPOCH);
         }
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft += time::Duration::nanoseconds(100);
+            ft += SignedDuration::nanoseconds(100);
             assert_eq!(ft, FileTime::new(1));
         }
 
         {
             let mut ft = FileTime::MAX;
-            ft += time::Duration::ZERO;
+            ft += SignedDuration::ZERO;
             assert_eq!(ft, FileTime::MAX);
         }
         {
             let mut ft = FileTime::MAX;
-            ft += time::Duration::NANOSECOND;
+            ft += SignedDuration::NANOSECOND;
             assert_eq!(ft, FileTime::MAX);
         }
         {
             let mut ft = FileTime::MAX;
-            ft += time::Duration::nanoseconds(99);
+            ft += SignedDuration::nanoseconds(99);
             assert_eq!(ft, FileTime::MAX);
         }
     }
 
     #[test]
     #[should_panic]
-    fn add_assign_positive_time_duration_with_overflow() {
+    fn add_assign_positive_time_signed_duration_with_overflow() {
         let mut ft = FileTime::MAX;
-        ft += time::Duration::nanoseconds(100);
+        ft += SignedDuration::nanoseconds(100);
     }
 
     #[test]
-    fn add_assign_negative_time_duration() {
+    fn add_assign_negative_time_signed_duration() {
         {
             let mut ft = FileTime::MAX;
-            ft += -time::Duration::ZERO;
+            ft += -SignedDuration::ZERO;
             assert_eq!(ft, FileTime::MAX);
         }
         {
             let mut ft = FileTime::MAX;
-            ft += -time::Duration::NANOSECOND;
+            ft += -SignedDuration::NANOSECOND;
             assert_eq!(ft, FileTime::MAX);
         }
         {
             let mut ft = FileTime::MAX;
-            ft += -time::Duration::nanoseconds(99);
+            ft += -SignedDuration::nanoseconds(99);
             assert_eq!(ft, FileTime::MAX);
         }
         {
             let mut ft = FileTime::MAX;
-            ft += -time::Duration::nanoseconds(100);
+            ft += -SignedDuration::nanoseconds(100);
             assert_eq!(ft, FileTime::new(u64::MAX - 1));
         }
 
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft += -time::Duration::ZERO;
+            ft += -SignedDuration::ZERO;
             assert_eq!(ft, FileTime::NT_TIME_EPOCH);
         }
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft += -time::Duration::NANOSECOND;
+            ft += -SignedDuration::NANOSECOND;
             assert_eq!(ft, FileTime::NT_TIME_EPOCH);
         }
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft += -time::Duration::nanoseconds(99);
+            ft += -SignedDuration::nanoseconds(99);
             assert_eq!(ft, FileTime::NT_TIME_EPOCH);
         }
     }
 
     #[test]
     #[should_panic]
-    fn add_assign_negative_time_duration_with_overflow() {
+    fn add_assign_negative_time_signed_duration_with_overflow() {
         let mut ft = FileTime::NT_TIME_EPOCH;
-        ft += -time::Duration::nanoseconds(100);
+        ft += -SignedDuration::nanoseconds(100);
     }
 
     #[cfg(feature = "chrono")]
@@ -1195,69 +1195,69 @@ mod tests {
     }
 
     #[test]
-    fn sub_positive_time_duration() {
-        assert_eq!(FileTime::MAX - time::Duration::ZERO, FileTime::MAX);
-        assert_eq!(FileTime::MAX - time::Duration::NANOSECOND, FileTime::MAX);
+    fn sub_positive_time_signed_duration() {
+        assert_eq!(FileTime::MAX - SignedDuration::ZERO, FileTime::MAX);
+        assert_eq!(FileTime::MAX - SignedDuration::NANOSECOND, FileTime::MAX);
         assert_eq!(
-            FileTime::MAX - time::Duration::nanoseconds(99),
+            FileTime::MAX - SignedDuration::nanoseconds(99),
             FileTime::MAX
         );
         assert_eq!(
-            FileTime::MAX - time::Duration::nanoseconds(100),
+            FileTime::MAX - SignedDuration::nanoseconds(100),
             FileTime::new(u64::MAX - 1)
         );
 
         assert_eq!(
-            FileTime::NT_TIME_EPOCH - time::Duration::ZERO,
+            FileTime::NT_TIME_EPOCH - SignedDuration::ZERO,
             FileTime::NT_TIME_EPOCH
         );
         assert_eq!(
-            FileTime::NT_TIME_EPOCH - time::Duration::NANOSECOND,
+            FileTime::NT_TIME_EPOCH - SignedDuration::NANOSECOND,
             FileTime::NT_TIME_EPOCH
         );
         assert_eq!(
-            FileTime::NT_TIME_EPOCH - time::Duration::nanoseconds(99),
+            FileTime::NT_TIME_EPOCH - SignedDuration::nanoseconds(99),
             FileTime::NT_TIME_EPOCH
         );
     }
 
     #[test]
     #[should_panic]
-    fn sub_positive_time_duration_with_overflow() {
-        let _ = FileTime::NT_TIME_EPOCH - time::Duration::nanoseconds(100);
+    fn sub_positive_time_signed_duration_with_overflow() {
+        let _ = FileTime::NT_TIME_EPOCH - SignedDuration::nanoseconds(100);
     }
 
     #[test]
-    fn sub_negative_time_duration() {
+    fn sub_negative_time_signed_duration() {
         assert_eq!(
-            FileTime::NT_TIME_EPOCH - -time::Duration::ZERO,
+            FileTime::NT_TIME_EPOCH - -SignedDuration::ZERO,
             FileTime::NT_TIME_EPOCH
         );
         assert_eq!(
-            FileTime::NT_TIME_EPOCH - -time::Duration::NANOSECOND,
+            FileTime::NT_TIME_EPOCH - -SignedDuration::NANOSECOND,
             FileTime::NT_TIME_EPOCH
         );
         assert_eq!(
-            FileTime::NT_TIME_EPOCH - -time::Duration::nanoseconds(99),
+            FileTime::NT_TIME_EPOCH - -SignedDuration::nanoseconds(99),
             FileTime::NT_TIME_EPOCH
         );
         assert_eq!(
-            FileTime::NT_TIME_EPOCH - -time::Duration::nanoseconds(100),
+            FileTime::NT_TIME_EPOCH - -SignedDuration::nanoseconds(100),
             FileTime::new(1)
         );
 
-        assert_eq!(FileTime::MAX - -time::Duration::ZERO, FileTime::MAX);
-        assert_eq!(FileTime::MAX - -time::Duration::NANOSECOND, FileTime::MAX);
+        assert_eq!(FileTime::MAX - -SignedDuration::ZERO, FileTime::MAX);
+        assert_eq!(FileTime::MAX - -SignedDuration::NANOSECOND, FileTime::MAX);
         assert_eq!(
-            FileTime::MAX - -time::Duration::nanoseconds(99),
+            FileTime::MAX - -SignedDuration::nanoseconds(99),
             FileTime::MAX
         );
     }
 
     #[test]
     #[should_panic]
-    fn sub_negative_time_duration_with_overflow() {
-        let _ = FileTime::MAX - -time::Duration::nanoseconds(100);
+    fn sub_negative_time_signed_duration_with_overflow() {
+        let _ = FileTime::MAX - -SignedDuration::nanoseconds(100);
     }
 
     #[cfg(feature = "chrono")]
@@ -1458,16 +1458,16 @@ mod tests {
         assert_eq!(
             utc_datetime!(9999-12-31 23:59:59.999_999_900)
                 - FileTime::new(2_650_467_743_999_999_999),
-            time::Duration::ZERO
+            SignedDuration::ZERO
         );
         assert_eq!(
             utc_datetime!(9999-12-31 23:59:59.999_999_900)
-                - (FileTime::new(2_650_467_743_999_999_999) - time::Duration::nanoseconds(100)),
-            time::Duration::nanoseconds(100)
+                - (FileTime::new(2_650_467_743_999_999_999) - SignedDuration::nanoseconds(100)),
+            SignedDuration::nanoseconds(100)
         );
         assert_eq!(
             utc_datetime!(9999-12-31 23:59:59.999_999_900) - FileTime::NT_TIME_EPOCH,
-            time::Duration::new(265_046_774_399, 999_999_900)
+            SignedDuration::new(265_046_774_399, 999_999_900)
         );
     }
 
@@ -1476,28 +1476,28 @@ mod tests {
         assert_eq!(
             FileTime::new(2_650_467_743_999_999_999)
                 - utc_datetime!(9999-12-31 23:59:59.999_999_900),
-            time::Duration::ZERO
+            SignedDuration::ZERO
         );
         assert_eq!(
             FileTime::new(2_650_467_743_999_999_999)
-                - (utc_datetime!(9999-12-31 23:59:59.999_999_900) - time::Duration::nanoseconds(1)),
-            time::Duration::nanoseconds(1)
-        );
-        assert_eq!(
-            FileTime::new(2_650_467_743_999_999_999)
-                - (utc_datetime!(9999-12-31 23:59:59.999_999_900)
-                    - time::Duration::nanoseconds(99)),
-            time::Duration::nanoseconds(99)
+                - (utc_datetime!(9999-12-31 23:59:59.999_999_900) - SignedDuration::nanoseconds(1)),
+            SignedDuration::nanoseconds(1)
         );
         assert_eq!(
             FileTime::new(2_650_467_743_999_999_999)
                 - (utc_datetime!(9999-12-31 23:59:59.999_999_900)
-                    - time::Duration::nanoseconds(100)),
-            time::Duration::nanoseconds(100)
+                    - SignedDuration::nanoseconds(99)),
+            SignedDuration::nanoseconds(99)
+        );
+        assert_eq!(
+            FileTime::new(2_650_467_743_999_999_999)
+                - (utc_datetime!(9999-12-31 23:59:59.999_999_900)
+                    - SignedDuration::nanoseconds(100)),
+            SignedDuration::nanoseconds(100)
         );
         assert_eq!(
             FileTime::new(2_650_467_743_999_999_999) - utc_datetime!(1601-01-01 00:00:00),
-            time::Duration::new(265_046_774_399, 999_999_900)
+            SignedDuration::new(265_046_774_399, 999_999_900)
         );
     }
 
@@ -1683,97 +1683,97 @@ mod tests {
     }
 
     #[test]
-    fn sub_assign_positive_time_duration() {
+    fn sub_assign_positive_time_signed_duration() {
         {
             let mut ft = FileTime::MAX;
-            ft -= time::Duration::ZERO;
+            ft -= SignedDuration::ZERO;
             assert_eq!(ft, FileTime::MAX);
         }
         {
             let mut ft = FileTime::MAX;
-            ft -= time::Duration::NANOSECOND;
+            ft -= SignedDuration::NANOSECOND;
             assert_eq!(ft, FileTime::MAX);
         }
         {
             let mut ft = FileTime::MAX;
-            ft -= time::Duration::nanoseconds(99);
+            ft -= SignedDuration::nanoseconds(99);
             assert_eq!(ft, FileTime::MAX);
         }
         {
             let mut ft = FileTime::MAX;
-            ft -= time::Duration::nanoseconds(100);
+            ft -= SignedDuration::nanoseconds(100);
             assert_eq!(ft, FileTime::new(u64::MAX - 1));
         }
 
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft -= time::Duration::ZERO;
+            ft -= SignedDuration::ZERO;
             assert_eq!(ft, FileTime::NT_TIME_EPOCH);
         }
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft -= time::Duration::NANOSECOND;
+            ft -= SignedDuration::NANOSECOND;
             assert_eq!(ft, FileTime::NT_TIME_EPOCH);
         }
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft -= time::Duration::nanoseconds(99);
+            ft -= SignedDuration::nanoseconds(99);
             assert_eq!(ft, FileTime::NT_TIME_EPOCH);
         }
     }
 
     #[test]
     #[should_panic]
-    fn sub_assign_positive_time_duration_with_overflow() {
+    fn sub_assign_positive_time_signed_duration_with_overflow() {
         let mut ft = FileTime::NT_TIME_EPOCH;
-        ft -= time::Duration::nanoseconds(100);
+        ft -= SignedDuration::nanoseconds(100);
     }
 
     #[test]
-    fn sub_assign_negative_time_duration() {
+    fn sub_assign_negative_time_signed_duration() {
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft -= -time::Duration::ZERO;
+            ft -= -SignedDuration::ZERO;
             assert_eq!(ft, FileTime::NT_TIME_EPOCH);
         }
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft -= -time::Duration::NANOSECOND;
+            ft -= -SignedDuration::NANOSECOND;
             assert_eq!(ft, FileTime::NT_TIME_EPOCH);
         }
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft -= -time::Duration::nanoseconds(99);
+            ft -= -SignedDuration::nanoseconds(99);
             assert_eq!(ft, FileTime::NT_TIME_EPOCH);
         }
         {
             let mut ft = FileTime::NT_TIME_EPOCH;
-            ft -= -time::Duration::nanoseconds(100);
+            ft -= -SignedDuration::nanoseconds(100);
             assert_eq!(ft, FileTime::new(1));
         }
 
         {
             let mut ft = FileTime::MAX;
-            ft -= -time::Duration::ZERO;
+            ft -= -SignedDuration::ZERO;
             assert_eq!(ft, FileTime::MAX);
         }
         {
             let mut ft = FileTime::MAX;
-            ft -= -time::Duration::NANOSECOND;
+            ft -= -SignedDuration::NANOSECOND;
             assert_eq!(ft, FileTime::MAX);
         }
         {
             let mut ft = FileTime::MAX;
-            ft -= -time::Duration::nanoseconds(99);
+            ft -= -SignedDuration::nanoseconds(99);
             assert_eq!(ft, FileTime::MAX);
         }
     }
 
     #[test]
     #[should_panic]
-    fn sub_assign_negative_time_duration_with_overflow() {
+    fn sub_assign_negative_time_signed_duration_with_overflow() {
         let mut ft = FileTime::MAX;
-        ft -= -time::Duration::nanoseconds(100);
+        ft -= -SignedDuration::nanoseconds(100);
     }
 
     #[cfg(feature = "chrono")]


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
`time::Duration` is an alias for `time::SignedDuration`.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/nt-time/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/nt-time/blob/develop/CODE_OF_CONDUCT.md
